### PR TITLE
feat: añadir hoja de estilos del sistema de diseño con navegación por secciones

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -3,6 +3,11 @@ import { MenuPageComponent } from './pages/menu/menu';
 import { MenuDefaultPageComponent } from './pages/menu-default/menu-default';
 import { MaestroApartamentosPageComponent } from './pages/maestro-apartamentos/maestro-apartamentos';
 import { SincronizadorContactosPageComponent } from './pages/sincronizador-contactos/sincronizador-contactos';
+import { HojaEstilosPageComponent } from './pages/hoja-estilos/hoja-estilos';
+import { DsTipografiaComponent } from './pages/hoja-estilos/secciones/tipografia/tipografia';
+import { DsAtomosComponent } from './pages/hoja-estilos/secciones/atomos/atomos';
+import { DsMoleculasComponent } from './pages/hoja-estilos/secciones/moleculas/moleculas';
+import { DsOrganismosComponent } from './pages/hoja-estilos/secciones/organismos/organismos';
 
 export const routes: Routes = [
   {
@@ -12,6 +17,17 @@ export const routes: Routes = [
       { path: '', component: MenuDefaultPageComponent },
       { path: 'maestro-apartamentos', component: MaestroApartamentosPageComponent },
       { path: 'sincronizador-contactos', component: SincronizadorContactosPageComponent },
+      {
+        path: 'hoja-estilos',
+        component: HojaEstilosPageComponent,
+        children: [
+          { path: '', redirectTo: 'tipografia', pathMatch: 'full' },
+          { path: 'tipografia', component: DsTipografiaComponent },
+          { path: 'atomos',     component: DsAtomosComponent     },
+          { path: 'moleculas',  component: DsMoleculasComponent  },
+          { path: 'organismos', component: DsOrganismosComponent },
+        ],
+      },
     ],
   },
 ];

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -3,11 +3,6 @@ import { MenuPageComponent } from './pages/menu/menu';
 import { MenuDefaultPageComponent } from './pages/menu-default/menu-default';
 import { MaestroApartamentosPageComponent } from './pages/maestro-apartamentos/maestro-apartamentos';
 import { SincronizadorContactosPageComponent } from './pages/sincronizador-contactos/sincronizador-contactos';
-import { HojaEstilosPageComponent } from './pages/hoja-estilos/hoja-estilos';
-import { DsTipografiaComponent } from './pages/hoja-estilos/secciones/tipografia/tipografia';
-import { DsAtomosComponent } from './pages/hoja-estilos/secciones/atomos/atomos';
-import { DsMoleculasComponent } from './pages/hoja-estilos/secciones/moleculas/moleculas';
-import { DsOrganismosComponent } from './pages/hoja-estilos/secciones/organismos/organismos';
 
 export const routes: Routes = [
   {
@@ -19,13 +14,13 @@ export const routes: Routes = [
       { path: 'sincronizador-contactos', component: SincronizadorContactosPageComponent },
       {
         path: 'hoja-estilos',
-        component: HojaEstilosPageComponent,
+        loadComponent: () => import('./pages/hoja-estilos/hoja-estilos').then(m => m.HojaEstilosPageComponent),
         children: [
           { path: '', redirectTo: 'tipografia', pathMatch: 'full' },
-          { path: 'tipografia', component: DsTipografiaComponent },
-          { path: 'atomos',     component: DsAtomosComponent     },
-          { path: 'moleculas',  component: DsMoleculasComponent  },
-          { path: 'organismos', component: DsOrganismosComponent },
+          { path: 'tipografia', loadComponent: () => import('./pages/hoja-estilos/secciones/tipografia/tipografia').then(m => m.DsTipografiaComponent) },
+          { path: 'atomos',     loadComponent: () => import('./pages/hoja-estilos/secciones/atomos/atomos').then(m => m.DsAtomosComponent)             },
+          { path: 'moleculas',  loadComponent: () => import('./pages/hoja-estilos/secciones/moleculas/moleculas').then(m => m.DsMoleculasComponent)     },
+          { path: 'organismos', loadComponent: () => import('./pages/hoja-estilos/secciones/organismos/organismos').then(m => m.DsOrganismosComponent)  },
         ],
       },
     ],

--- a/frontend/src/app/components/sidenav/sidenav.ts
+++ b/frontend/src/app/components/sidenav/sidenav.ts
@@ -9,11 +9,11 @@ interface Tool {
 }
 
 const TOOLS: Tool[] = [
-  { id: 'maestro-apartamentos', label: 'Maestro de apartamentos', route: '/menu/maestro-apartamentos' },
+  { id: 'maestro-apartamentos',   label: 'Maestro de apartamentos',   route: '/menu/maestro-apartamentos'   },
   { id: 'sincronizador-contactos', label: 'Sincronizador de contactos', route: '/menu/sincronizador-contactos' },
   { id: 'tool-3', label: 'Herramienta 3', route: null },
   { id: 'tool-4', label: 'Herramienta 4', route: null },
-  { id: 'tool-5', label: 'Herramienta 5', route: null },
+  { id: 'hoja-estilos',           label: 'Hoja de estilos',           route: '/menu/hoja-estilos'           },
 ];
 
 @Component({

--- a/frontend/src/app/pages/hoja-estilos/hoja-estilos.html
+++ b/frontend/src/app/pages/hoja-estilos/hoja-estilos.html
@@ -1,0 +1,28 @@
+<div class="ds-layout">
+
+  <!-- Nav secundaria — secciones del design system -->
+  <nav class="ds-nav" aria-label="Secciones del sistema de diseño">
+    <p class="ds-nav__title">Sistema de diseño</p>
+    <ul class="ds-nav__list" role="list">
+      @for (section of sections; track section.id) {
+        <li>
+          <a
+            class="ds-nav__link"
+            [routerLink]="section.route"
+            routerLinkActive="ds-nav__link--active"
+            [attr.aria-current]="null"
+          >
+            <span class="ds-nav__dot" aria-hidden="true"></span>
+            {{ section.label }}
+          </a>
+        </li>
+      }
+    </ul>
+  </nav>
+
+  <!-- Contenido: renderiza la sección activa -->
+  <div class="ds-content">
+    <router-outlet />
+  </div>
+
+</div>

--- a/frontend/src/app/pages/hoja-estilos/hoja-estilos.html
+++ b/frontend/src/app/pages/hoja-estilos/hoja-estilos.html
@@ -10,7 +10,8 @@
             class="ds-nav__link"
             [routerLink]="section.route"
             routerLinkActive="ds-nav__link--active"
-            [attr.aria-current]="null"
+            #rla="routerLinkActive"
+            [attr.aria-current]="rla.isActive ? 'page' : null"
           >
             <span class="ds-nav__dot" aria-hidden="true"></span>
             {{ section.label }}

--- a/frontend/src/app/pages/hoja-estilos/hoja-estilos.scss
+++ b/frontend/src/app/pages/hoja-estilos/hoja-estilos.scss
@@ -1,0 +1,1 @@
+// Estilos en la hoja SCSS global — src/styles/components/_hoja-estilos.scss

--- a/frontend/src/app/pages/hoja-estilos/hoja-estilos.ts
+++ b/frontend/src/app/pages/hoja-estilos/hoja-estilos.ts
@@ -1,0 +1,26 @@
+import { Component } from '@angular/core';
+import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
+
+interface DsSection {
+  id: string;
+  label: string;
+  route: string;
+}
+
+const SECTIONS: DsSection[] = [
+  { id: 'tipografia', label: 'Tipografía',  route: 'tipografia'  },
+  { id: 'atomos',     label: 'Átomos',      route: 'atomos'      },
+  { id: 'moleculas',  label: 'Moléculas',   route: 'moleculas'   },
+  { id: 'organismos', label: 'Organismos',  route: 'organismos'  },
+];
+
+@Component({
+  selector: 'app-hoja-estilos-page',
+  templateUrl: './hoja-estilos.html',
+  styleUrl: './hoja-estilos.scss',
+  standalone: true,
+  imports: [RouterLink, RouterLinkActive, RouterOutlet],
+})
+export class HojaEstilosPageComponent {
+  readonly sections: DsSection[] = SECTIONS;
+}

--- a/frontend/src/app/pages/hoja-estilos/secciones/atomos/atomos.html
+++ b/frontend/src/app/pages/hoja-estilos/secciones/atomos/atomos.html
@@ -1,0 +1,286 @@
+<div class="ds-section">
+
+  <div class="ds-section__header">
+    <h2 class="ds-section__title">Átomos</h2>
+    <p class="ds-section__desc">
+      Los elementos más pequeños e indivisibles del sistema: botones, badges, iconos SVG y logo.
+    </p>
+  </div>
+
+  <!-- =========================================================
+       BOTÓN PRIMARIO
+  ========================================================== -->
+  <div class="ds-block">
+    <p class="ds-block__label">Botón primario</p>
+    <div class="ds-block__body">
+
+      <!-- Tamaños -->
+      <div class="ds-row">
+        <div class="ds-specimen">
+          <span class="ds-specimen__label">sm</span>
+          <div class="ds-specimen__preview">
+            <button class="btn btn--primary btn--sm" type="button">Acción</button>
+          </div>
+          <span class="ds-specimen__meta">btn--primary btn--sm</span>
+        </div>
+
+        <div class="ds-specimen">
+          <span class="ds-specimen__label">md (default)</span>
+          <div class="ds-specimen__preview">
+            <button class="btn btn--primary btn--md" type="button">Acción</button>
+          </div>
+          <span class="ds-specimen__meta">btn--primary btn--md</span>
+        </div>
+
+        <div class="ds-specimen">
+          <span class="ds-specimen__label">lg</span>
+          <div class="ds-specimen__preview">
+            <button class="btn btn--primary btn--lg" type="button">Acción</button>
+          </div>
+          <span class="ds-specimen__meta">btn--primary btn--lg</span>
+        </div>
+      </div>
+
+      <!-- Con icono y deshabilitado -->
+      <div class="ds-row">
+        <div class="ds-specimen">
+          <span class="ds-specimen__label">con icono</span>
+          <div class="ds-specimen__preview">
+            <button class="btn btn--primary btn--md" type="button">
+              <span class="btn__icon" aria-hidden="true">
+                <svg class="svg svg--sm" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+                  <circle cx="10" cy="10" r="8" fill="none" stroke="currentColor" stroke-width="2"/>
+                  <line x1="10" y1="6" x2="10" y2="14" stroke="currentColor" stroke-width="2"/>
+                  <line x1="6" y1="10" x2="14" y2="10" stroke="currentColor" stroke-width="2"/>
+                </svg>
+              </span>
+              Añadir
+            </button>
+          </div>
+          <span class="ds-specimen__meta">btn__icon + svg--sm</span>
+        </div>
+
+        <div class="ds-specimen">
+          <span class="ds-specimen__label">deshabilitado</span>
+          <div class="ds-specimen__preview">
+            <button class="btn btn--primary btn--md" type="button" disabled>Acción</button>
+          </div>
+          <span class="ds-specimen__meta">disabled → opacity 0.4</span>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- =========================================================
+       BOTÓN SECUNDARIO
+  ========================================================== -->
+  <div class="ds-block">
+    <p class="ds-block__label">Botón secundario</p>
+    <div class="ds-block__body">
+
+      <div class="ds-row">
+        <div class="ds-specimen">
+          <span class="ds-specimen__label">sm</span>
+          <div class="ds-specimen__preview">
+            <button class="btn btn--secondary btn--sm" type="button">Acción</button>
+          </div>
+          <span class="ds-specimen__meta">btn--secondary btn--sm</span>
+        </div>
+
+        <div class="ds-specimen">
+          <span class="ds-specimen__label">md (default)</span>
+          <div class="ds-specimen__preview">
+            <button class="btn btn--secondary btn--md" type="button">Acción</button>
+          </div>
+          <span class="ds-specimen__meta">btn--secondary btn--md</span>
+        </div>
+
+        <div class="ds-specimen">
+          <span class="ds-specimen__label">lg</span>
+          <div class="ds-specimen__preview">
+            <button class="btn btn--secondary btn--lg" type="button">Acción</button>
+          </div>
+          <span class="ds-specimen__meta">btn--secondary btn--lg</span>
+        </div>
+
+        <div class="ds-specimen">
+          <span class="ds-specimen__label">deshabilitado</span>
+          <div class="ds-specimen__preview">
+            <button class="btn btn--secondary btn--md" type="button" disabled>Acción</button>
+          </div>
+          <span class="ds-specimen__meta">disabled → opacity 0.4</span>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- =========================================================
+       BADGES
+  ========================================================== -->
+  <div class="ds-block">
+    <p class="ds-block__label">Badge</p>
+    <div class="ds-block__body">
+
+      <div class="ds-row">
+        <div class="ds-specimen">
+          <span class="ds-specimen__label">default</span>
+          <div class="ds-specimen__preview">
+            <span class="badge badge--default">Pendiente</span>
+          </div>
+          <span class="ds-specimen__meta">badge--default</span>
+        </div>
+
+        <div class="ds-specimen">
+          <span class="ds-specimen__label">outline</span>
+          <div class="ds-specimen__preview">
+            <span class="badge badge--outline">En proceso</span>
+          </div>
+          <span class="ds-specimen__meta">badge--outline</span>
+        </div>
+
+        <div class="ds-specimen">
+          <span class="ds-specimen__label">solid</span>
+          <div class="ds-specimen__preview">
+            <span class="badge badge--solid">Completado</span>
+          </div>
+          <span class="ds-specimen__meta">badge--solid</span>
+        </div>
+
+        <div class="ds-specimen">
+          <span class="ds-specimen__label">con dot</span>
+          <div class="ds-specimen__preview">
+            <span class="badge badge--default">
+              <span class="badge__dot" aria-hidden="true"></span>
+              Activo
+            </span>
+          </div>
+          <span class="ds-specimen__meta">badge__dot</span>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- =========================================================
+       SVG — TAMAÑOS
+  ========================================================== -->
+  <div class="ds-block">
+    <p class="ds-block__label">SVG — tamaños</p>
+    <div class="ds-block__body">
+
+      <div class="ds-row">
+        <div class="ds-specimen">
+          <span class="ds-specimen__label">xs — 16px</span>
+          <div class="ds-specimen__preview">
+            <svg class="svg svg--xs" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+              <rect x="2" y="2" width="20" height="20" fill="#d4d4d4"/>
+              <rect x="6" y="10" width="5" height="9" fill="#8c8c8c"/>
+              <rect x="13" y="6" width="5" height="13" fill="#8c8c8c"/>
+            </svg>
+          </div>
+          <span class="ds-specimen__meta">svg--xs · 1rem</span>
+        </div>
+
+        <div class="ds-specimen">
+          <span class="ds-specimen__label">sm — 20px</span>
+          <div class="ds-specimen__preview">
+            <svg class="svg svg--sm" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+              <rect x="2" y="2" width="20" height="20" fill="#d4d4d4"/>
+              <rect x="6" y="10" width="5" height="9" fill="#8c8c8c"/>
+              <rect x="13" y="6" width="5" height="13" fill="#8c8c8c"/>
+            </svg>
+          </div>
+          <span class="ds-specimen__meta">svg--sm · 1.25rem</span>
+        </div>
+
+        <div class="ds-specimen">
+          <span class="ds-specimen__label">md — 24px</span>
+          <div class="ds-specimen__preview">
+            <svg class="svg svg--md" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+              <rect x="2" y="2" width="20" height="20" fill="#d4d4d4"/>
+              <rect x="6" y="10" width="5" height="9" fill="#8c8c8c"/>
+              <rect x="13" y="6" width="5" height="13" fill="#8c8c8c"/>
+            </svg>
+          </div>
+          <span class="ds-specimen__meta">svg--md · 1.5rem</span>
+        </div>
+
+        <div class="ds-specimen">
+          <span class="ds-specimen__label">lg — 32px</span>
+          <div class="ds-specimen__preview">
+            <svg class="svg svg--lg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+              <rect x="2" y="2" width="20" height="20" fill="#d4d4d4"/>
+              <rect x="6" y="10" width="5" height="9" fill="#8c8c8c"/>
+              <rect x="13" y="6" width="5" height="13" fill="#8c8c8c"/>
+            </svg>
+          </div>
+          <span class="ds-specimen__meta">svg--lg · 2rem</span>
+        </div>
+
+        <div class="ds-specimen">
+          <span class="ds-specimen__label">xl — 48px</span>
+          <div class="ds-specimen__preview">
+            <svg class="svg svg--xl" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+              <rect x="2" y="2" width="20" height="20" fill="#d4d4d4"/>
+              <rect x="6" y="10" width="5" height="9" fill="#8c8c8c"/>
+              <rect x="13" y="6" width="5" height="13" fill="#8c8c8c"/>
+            </svg>
+          </div>
+          <span class="ds-specimen__meta">svg--xl · 3rem</span>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- =========================================================
+       LOGO
+  ========================================================== -->
+  <div class="ds-block">
+    <p class="ds-block__label">Logo</p>
+    <div class="ds-block__body">
+
+      <div class="ds-row">
+        <div class="ds-specimen">
+          <span class="ds-specimen__label">normal</span>
+          <div class="ds-specimen__preview">
+            <a href="#" class="logo" aria-label="Stay Sidekick">
+              <span class="logo__icon" aria-hidden="true">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+                  <rect width="32" height="32" fill="#2e2e2e"/>
+                  <rect x="8" y="14" width="7" height="10" fill="#fff"/>
+                  <rect x="17" y="8" width="7" height="16" fill="#fff"/>
+                  <rect x="8" y="8" width="7" height="4" fill="#fff"/>
+                </svg>
+              </span>
+              <span class="logo__name">Stay Sidekick</span>
+            </a>
+          </div>
+          <span class="ds-specimen__meta">.logo</span>
+        </div>
+
+        <div class="ds-specimen">
+          <span class="ds-specimen__label">grande</span>
+          <div class="ds-specimen__preview">
+            <a href="#" class="logo logo--lg" aria-label="Stay Sidekick">
+              <span class="logo__icon" aria-hidden="true">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+                  <rect width="32" height="32" fill="#2e2e2e"/>
+                  <rect x="8" y="14" width="7" height="10" fill="#fff"/>
+                  <rect x="17" y="8" width="7" height="16" fill="#fff"/>
+                  <rect x="8" y="8" width="7" height="4" fill="#fff"/>
+                </svg>
+              </span>
+              <span class="logo__name">Stay Sidekick</span>
+            </a>
+          </div>
+          <span class="ds-specimen__meta">.logo.logo--lg</span>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+</div>

--- a/frontend/src/app/pages/hoja-estilos/secciones/atomos/atomos.ts
+++ b/frontend/src/app/pages/hoja-estilos/secciones/atomos/atomos.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-ds-atomos',
+  templateUrl: './atomos.html',
+  standalone: true,
+})
+export class DsAtomosComponent {}

--- a/frontend/src/app/pages/hoja-estilos/secciones/moleculas/moleculas.html
+++ b/frontend/src/app/pages/hoja-estilos/secciones/moleculas/moleculas.html
@@ -1,0 +1,217 @@
+<div class="ds-section">
+
+  <div class="ds-section__header">
+    <h2 class="ds-section__title">Moléculas</h2>
+    <p class="ds-section__desc">
+      Combinaciones de átomos que forman componentes de formulario reutilizables.
+      Todos los estados: normal, foco y error.
+    </p>
+  </div>
+
+  <!-- =========================================================
+       INPUT
+  ========================================================== -->
+  <div class="ds-block">
+    <p class="ds-block__label">Input</p>
+    <div class="ds-block__body">
+
+      <div class="ds-row">
+        <div class="ds-specimen" style="min-width:260px">
+          <span class="ds-specimen__label">normal</span>
+          <div class="ds-specimen__preview" style="width:100%">
+            <div class="form-field" style="width:100%">
+              <label class="form-label" for="ds-input-normal">Nombre</label>
+              <input class="form-input" id="ds-input-normal" type="text" placeholder="Ej. María García">
+            </div>
+          </div>
+          <span class="ds-specimen__meta">.form-field > .form-label + .form-input</span>
+        </div>
+
+        <div class="ds-specimen" style="min-width:260px">
+          <span class="ds-specimen__label">con icono</span>
+          <div class="ds-specimen__preview" style="width:100%">
+            <div class="form-field" style="width:100%">
+              <label class="form-label" for="ds-input-icon">Correo</label>
+              <div class="form-input-wrapper">
+                <span class="form-input-wrapper__icon" aria-hidden="true">
+                  <svg class="svg svg--sm" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none">
+                    <rect x="2" y="5" width="16" height="12" rx="1" stroke="currentColor" stroke-width="1.5"/>
+                    <polyline points="2,6 10,12 18,6" stroke="currentColor" stroke-width="1.5" fill="none"/>
+                  </svg>
+                </span>
+                <input class="form-input" id="ds-input-icon" type="email" placeholder="nombre@empresa.com">
+              </div>
+            </div>
+          </div>
+          <span class="ds-specimen__meta">.form-input-wrapper > __icon + .form-input</span>
+        </div>
+
+        <div class="ds-specimen" style="min-width:260px">
+          <span class="ds-specimen__label">error</span>
+          <div class="ds-specimen__preview" style="width:100%">
+            <div class="form-field form-field--error" style="width:100%">
+              <label class="form-label" for="ds-input-error">Teléfono</label>
+              <input class="form-input" id="ds-input-error" type="tel" value="123abc" aria-describedby="ds-input-error-msg">
+              <span class="form-field__error" id="ds-input-error-msg">Formato de teléfono no válido.</span>
+            </div>
+          </div>
+          <span class="ds-specimen__meta">.form-field--error + .form-field__error</span>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- =========================================================
+       SELECT
+  ========================================================== -->
+  <div class="ds-block">
+    <p class="ds-block__label">Select</p>
+    <div class="ds-block__body">
+      <div class="ds-row">
+        <div class="ds-specimen" style="min-width:260px">
+          <span class="ds-specimen__label">normal</span>
+          <div class="ds-specimen__preview" style="width:100%">
+            <div class="form-field" style="width:100%">
+              <label class="form-label" for="ds-select">Tipo de solicitud</label>
+              <select class="form-select" id="ds-select">
+                <option value="">Selecciona una opción</option>
+                <option value="beneficiario">Beneficiario</option>
+                <option value="empresa">Empresa interesada</option>
+              </select>
+            </div>
+          </div>
+          <span class="ds-specimen__meta">.form-select</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- =========================================================
+       TEXTAREA
+  ========================================================== -->
+  <div class="ds-block">
+    <p class="ds-block__label">Textarea</p>
+    <div class="ds-block__body">
+      <div class="ds-row">
+        <div class="ds-specimen" style="min-width:360px">
+          <span class="ds-specimen__label">normal</span>
+          <div class="ds-specimen__preview" style="width:100%">
+            <div class="form-field" style="width:100%">
+              <label class="form-label" for="ds-textarea">Mensaje</label>
+              <textarea class="form-textarea" id="ds-textarea" placeholder="Escribe aquí tu mensaje..."></textarea>
+            </div>
+          </div>
+          <span class="ds-specimen__meta">.form-textarea</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- =========================================================
+       EDITOR ESTILO GITHUB
+  ========================================================== -->
+  <div class="ds-block">
+    <p class="ds-block__label">Editor enriquecido (estilo GitHub)</p>
+    <div class="ds-block__body">
+      <div class="ds-row">
+        <div class="ds-specimen" style="min-width:420px">
+          <span class="ds-specimen__label">con tabs y toolbar</span>
+          <div class="ds-specimen__preview" style="width:100%">
+            <div class="form-field" style="width:100%">
+              <label class="form-label" for="ds-editor">Descripción de la solicitud</label>
+              <div class="form-editor">
+                <div class="form-editor__header">
+                  <div class="form-editor__tabs" role="tablist">
+                    <button class="form-editor__tab form-editor__tab--active" role="tab" aria-selected="true">Escribir</button>
+                    <button class="form-editor__tab" role="tab" aria-selected="false">Vista previa</button>
+                  </div>
+                  <div class="form-editor__toolbar" aria-label="Formato">
+                    <button class="form-editor__tool" type="button" title="Negrita"><strong>B</strong></button>
+                    <button class="form-editor__tool" type="button" title="Cursiva"><em>I</em></button>
+                    <span class="form-editor__tool form-editor__tool--separator" aria-hidden="true"></span>
+                    <button class="form-editor__tool" type="button" title="Lista">≡</button>
+                  </div>
+                </div>
+                <div class="form-editor__body">
+                  <textarea class="form-textarea" id="ds-editor" placeholder="Describe tu solicitud con detalle..."></textarea>
+                </div>
+              </div>
+            </div>
+          </div>
+          <span class="ds-specimen__meta">.form-editor > __header (__tabs + __toolbar) + __body</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- =========================================================
+       RADIO Y CHECKBOX
+  ========================================================== -->
+  <div class="ds-block">
+    <p class="ds-block__label">Radio y Checkbox</p>
+    <div class="ds-block__body">
+
+      <div class="ds-row">
+        <div class="ds-specimen">
+          <span class="ds-specimen__label">radio group</span>
+          <div class="ds-specimen__preview">
+            <div class="form-group" role="radiogroup" aria-labelledby="ds-radio-legend">
+              <p id="ds-radio-legend" class="form-label">Tipo de usuario</p>
+              <label class="form-choice">
+                <input class="form-choice__input" type="radio" name="ds-tipo" value="beneficiario">
+                <span class="form-choice__label">Beneficiario actual</span>
+              </label>
+              <label class="form-choice">
+                <input class="form-choice__input" type="radio" name="ds-tipo" value="empresa">
+                <span class="form-choice__label">Empresa interesada</span>
+              </label>
+            </div>
+          </div>
+          <span class="ds-specimen__meta">.form-group[radiogroup] > .form-choice</span>
+        </div>
+
+        <div class="ds-specimen">
+          <span class="ds-specimen__label">checkbox group</span>
+          <div class="ds-specimen__preview">
+            <div class="form-group">
+              <label class="form-choice">
+                <input class="form-choice__input" type="checkbox">
+                <span class="form-choice__label">
+                  Acepto los <a href="#">términos y condiciones</a>
+                </span>
+              </label>
+              <label class="form-choice">
+                <input class="form-choice__input" type="checkbox">
+                <span class="form-choice__label">
+                  Acepto la <a href="#">política de privacidad</a>
+                </span>
+              </label>
+            </div>
+          </div>
+          <span class="ds-specimen__meta">.form-group > .form-choice[checkbox]</span>
+        </div>
+
+        <div class="ds-specimen">
+          <span class="ds-specimen__label">radio group — error</span>
+          <div class="ds-specimen__preview">
+            <div class="form-group form-group--error" role="radiogroup">
+              <label class="form-choice">
+                <input class="form-choice__input" type="radio" name="ds-tipo-err" value="a">
+                <span class="form-choice__label">Opción A</span>
+              </label>
+              <label class="form-choice">
+                <input class="form-choice__input" type="radio" name="ds-tipo-err" value="b">
+                <span class="form-choice__label">Opción B</span>
+              </label>
+              <span class="form-group__error">Debes seleccionar una opción.</span>
+            </div>
+          </div>
+          <span class="ds-specimen__meta">.form-group--error + .form-group__error</span>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+</div>

--- a/frontend/src/app/pages/hoja-estilos/secciones/moleculas/moleculas.html
+++ b/frontend/src/app/pages/hoja-estilos/secciones/moleculas/moleculas.html
@@ -16,10 +16,10 @@
     <div class="ds-block__body">
 
       <div class="ds-row">
-        <div class="ds-specimen" style="min-width:260px">
+        <div class="ds-specimen" class="ds-specimen--form">
           <span class="ds-specimen__label">normal</span>
-          <div class="ds-specimen__preview" style="width:100%">
-            <div class="form-field" style="width:100%">
+          <div class="ds-specimen__preview">
+            <div class="form-field">
               <label class="form-label" for="ds-input-normal">Nombre</label>
               <input class="form-input" id="ds-input-normal" type="text" placeholder="Ej. María García">
             </div>
@@ -27,10 +27,10 @@
           <span class="ds-specimen__meta">.form-field > .form-label + .form-input</span>
         </div>
 
-        <div class="ds-specimen" style="min-width:260px">
+        <div class="ds-specimen" class="ds-specimen--form">
           <span class="ds-specimen__label">con icono</span>
-          <div class="ds-specimen__preview" style="width:100%">
-            <div class="form-field" style="width:100%">
+          <div class="ds-specimen__preview">
+            <div class="form-field">
               <label class="form-label" for="ds-input-icon">Correo</label>
               <div class="form-input-wrapper">
                 <span class="form-input-wrapper__icon" aria-hidden="true">
@@ -46,10 +46,10 @@
           <span class="ds-specimen__meta">.form-input-wrapper > __icon + .form-input</span>
         </div>
 
-        <div class="ds-specimen" style="min-width:260px">
+        <div class="ds-specimen" class="ds-specimen--form">
           <span class="ds-specimen__label">error</span>
-          <div class="ds-specimen__preview" style="width:100%">
-            <div class="form-field form-field--error" style="width:100%">
+          <div class="ds-specimen__preview">
+            <div class="form-field form-field--error">
               <label class="form-label" for="ds-input-error">Teléfono</label>
               <input class="form-input" id="ds-input-error" type="tel" value="123abc" aria-describedby="ds-input-error-msg">
               <span class="form-field__error" id="ds-input-error-msg">Formato de teléfono no válido.</span>
@@ -69,10 +69,10 @@
     <p class="ds-block__label">Select</p>
     <div class="ds-block__body">
       <div class="ds-row">
-        <div class="ds-specimen" style="min-width:260px">
+        <div class="ds-specimen" class="ds-specimen--form">
           <span class="ds-specimen__label">normal</span>
-          <div class="ds-specimen__preview" style="width:100%">
-            <div class="form-field" style="width:100%">
+          <div class="ds-specimen__preview">
+            <div class="form-field">
               <label class="form-label" for="ds-select">Tipo de solicitud</label>
               <select class="form-select" id="ds-select">
                 <option value="">Selecciona una opción</option>
@@ -94,10 +94,10 @@
     <p class="ds-block__label">Textarea</p>
     <div class="ds-block__body">
       <div class="ds-row">
-        <div class="ds-specimen" style="min-width:360px">
+        <div class="ds-specimen" class="ds-specimen--form-wide">
           <span class="ds-specimen__label">normal</span>
-          <div class="ds-specimen__preview" style="width:100%">
-            <div class="form-field" style="width:100%">
+          <div class="ds-specimen__preview">
+            <div class="form-field">
               <label class="form-label" for="ds-textarea">Mensaje</label>
               <textarea class="form-textarea" id="ds-textarea" placeholder="Escribe aquí tu mensaje..."></textarea>
             </div>
@@ -115,10 +115,10 @@
     <p class="ds-block__label">Editor enriquecido (estilo GitHub)</p>
     <div class="ds-block__body">
       <div class="ds-row">
-        <div class="ds-specimen" style="min-width:420px">
+        <div class="ds-specimen" class="ds-specimen--form-xl">
           <span class="ds-specimen__label">con tabs y toolbar</span>
-          <div class="ds-specimen__preview" style="width:100%">
-            <div class="form-field" style="width:100%">
+          <div class="ds-specimen__preview">
+            <div class="form-field">
               <label class="form-label" for="ds-editor">Descripción de la solicitud</label>
               <div class="form-editor">
                 <div class="form-editor__header">

--- a/frontend/src/app/pages/hoja-estilos/secciones/moleculas/moleculas.ts
+++ b/frontend/src/app/pages/hoja-estilos/secciones/moleculas/moleculas.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-ds-moleculas',
+  templateUrl: './moleculas.html',
+  standalone: true,
+})
+export class DsMoleculasComponent {}

--- a/frontend/src/app/pages/hoja-estilos/secciones/organismos/organismos.html
+++ b/frontend/src/app/pages/hoja-estilos/secciones/organismos/organismos.html
@@ -1,0 +1,204 @@
+<div class="ds-section">
+
+  <div class="ds-section__header">
+    <h2 class="ds-section__title">Organismos</h2>
+    <p class="ds-section__desc">
+      Componentes de alto nivel compuestos por átomos y moléculas.
+      Se muestran en previsualizaciones acotadas que anulan el posicionamiento fijo/sticky.
+    </p>
+  </div>
+
+  <!-- =========================================================
+       HEADER
+  ========================================================== -->
+  <div class="ds-block">
+    <p class="ds-block__label">Header — barra de navegación principal</p>
+    <div class="ds-block__body">
+
+      <p style="font-size:0.75rem;color:#6b6b6b;margin-bottom:0.5rem">
+        BEM: <code>.header > .header__inner > .header__start (.header__brand) + .header__actions</code>
+      </p>
+
+      <!-- Preview acotada — .header pierde position:sticky dentro del contenedor overflow:hidden -->
+      <div class="ds-organism-preview">
+        <header class="header" role="banner">
+          <div class="header__inner">
+            <div class="header__start">
+
+              <!-- Botón hamburguesa (placeholder) -->
+              <button class="header__nav-toggle" type="button" aria-label="Abrir menú lateral" aria-expanded="false">
+                <svg class="svg svg--sm" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none">
+                  <line x1="3" y1="5"  x2="17" y2="5"  stroke="currentColor" stroke-width="1.5"/>
+                  <line x1="3" y1="10" x2="17" y2="10" stroke="currentColor" stroke-width="1.5"/>
+                  <line x1="3" y1="15" x2="17" y2="15" stroke="currentColor" stroke-width="1.5"/>
+                </svg>
+              </button>
+
+              <!-- Logo -->
+              <a href="#" class="logo header__brand" aria-label="Stay Sidekick — inicio">
+                <span class="logo__icon" aria-hidden="true">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+                    <rect width="32" height="32" fill="#2e2e2e"/>
+                    <rect x="8" y="14" width="7" height="10" fill="#fff"/>
+                    <rect x="17" y="8" width="7" height="16" fill="#fff"/>
+                    <rect x="8" y="8" width="7" height="4" fill="#fff"/>
+                  </svg>
+                </span>
+                <span class="logo__name">Stay Sidekick</span>
+              </a>
+
+            </div>
+
+            <!-- Acciones -->
+            <div class="header__actions">
+              <button class="btn btn--secondary btn--sm" type="button">Iniciar sesión</button>
+              <button class="btn btn--primary btn--sm" type="button">Presentar solicitud</button>
+            </div>
+          </div>
+        </header>
+      </div>
+
+      <!-- Variante: header sin toggle (web pública) -->
+      <p class="ds-specimen__label" style="margin-top:1rem">Sin toggle (web estática)</p>
+      <div class="ds-organism-preview">
+        <header class="header" role="banner">
+          <div class="header__inner">
+            <div class="header__start">
+              <a href="#" class="logo header__brand" aria-label="Stay Sidekick — inicio">
+                <span class="logo__icon" aria-hidden="true">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+                    <rect width="32" height="32" fill="#2e2e2e"/>
+                    <rect x="8" y="14" width="7" height="10" fill="#fff"/>
+                    <rect x="17" y="8" width="7" height="16" fill="#fff"/>
+                    <rect x="8" y="8" width="7" height="4" fill="#fff"/>
+                  </svg>
+                </span>
+                <span class="logo__name">Stay Sidekick</span>
+              </a>
+            </div>
+            <div class="header__actions">
+              <button class="btn btn--secondary btn--sm" type="button">Iniciar sesión</button>
+              <button class="btn btn--primary btn--sm" type="button">Presentar solicitud</button>
+            </div>
+          </div>
+        </header>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- =========================================================
+       NAV SIDENAV
+  ========================================================== -->
+  <div class="ds-block">
+    <p class="ds-block__label">Nav sidenav — menú lateral de herramientas</p>
+    <div class="ds-block__body">
+
+      <p style="font-size:0.75rem;color:#6b6b6b;margin-bottom:0.5rem">
+        BEM: <code>.nav-sidenav > .nav-sidenav__tools (ul > li > a) + .nav-sidenav__footer (button)</code>
+      </p>
+
+      <!-- Estado expandido -->
+      <p class="ds-specimen__label">Expandido</p>
+      <div class="ds-organism-preview" style="display:flex">
+        <nav class="nav-sidenav" aria-label="Menú de herramientas — preview">
+          <ul class="nav-sidenav__tools" role="list">
+            <li class="nav-sidenav__item">
+              <a href="#" class="nav-sidenav__tool-link nav-sidenav__tool-link--active" aria-current="page">
+                <span class="nav-sidenav__tool-icon" aria-hidden="true">
+                  <svg class="svg svg--md" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+                    <rect x="2" y="2" width="20" height="20" fill="#d4d4d4"/>
+                    <rect x="6" y="10" width="5" height="9" fill="#8c8c8c"/>
+                    <rect x="13" y="6" width="5" height="13" fill="#8c8c8c"/>
+                  </svg>
+                </span>
+                <span class="nav-sidenav__tool-label">Maestro de apartamentos</span>
+              </a>
+            </li>
+            <li class="nav-sidenav__item">
+              <a href="#" class="nav-sidenav__tool-link">
+                <span class="nav-sidenav__tool-icon" aria-hidden="true">
+                  <svg class="svg svg--md" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+                    <rect x="2" y="2" width="20" height="20" fill="#d4d4d4"/>
+                    <rect x="6" y="10" width="5" height="9" fill="#8c8c8c"/>
+                    <rect x="13" y="6" width="5" height="13" fill="#8c8c8c"/>
+                  </svg>
+                </span>
+                <span class="nav-sidenav__tool-label">Sincronizador de contactos</span>
+              </a>
+            </li>
+            <li class="nav-sidenav__item">
+              <a href="#" class="nav-sidenav__tool-link nav-sidenav__tool-link--disabled" aria-disabled="true">
+                <span class="nav-sidenav__tool-icon" aria-hidden="true">
+                  <svg class="svg svg--md" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+                    <rect x="2" y="2" width="20" height="20" fill="#d4d4d4"/>
+                    <rect x="6" y="10" width="5" height="9" fill="#8c8c8c"/>
+                    <rect x="13" y="6" width="5" height="13" fill="#8c8c8c"/>
+                  </svg>
+                </span>
+                <span class="nav-sidenav__tool-label">Herramienta 3 (próximamente)</span>
+              </a>
+            </li>
+          </ul>
+          <footer class="nav-sidenav__footer">
+            <button class="nav-sidenav__collapse-btn" type="button" aria-label="Colapsar menú lateral" aria-expanded="true">
+              <span class="nav-sidenav__collapse-icon" aria-hidden="true">
+                <svg class="svg svg--sm" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none">
+                  <polyline points="15,4 9,10 15,16" stroke="#4a4a4a" stroke-width="2" stroke-linecap="square"/>
+                  <polyline points="10,4 4,10 10,16"  stroke="#4a4a4a" stroke-width="2" stroke-linecap="square"/>
+                </svg>
+              </span>
+              <span class="nav-sidenav__collapse-label">Colapsar menú</span>
+            </button>
+          </footer>
+        </nav>
+      </div>
+
+      <!-- Estado colapsado -->
+      <p class="ds-specimen__label" style="margin-top:1rem">Colapsado — solo iconos</p>
+      <div class="ds-organism-preview" style="display:flex;width:fit-content">
+        <nav class="nav-sidenav nav-sidenav--collapsed" aria-label="Menú de herramientas — colapsado">
+          <ul class="nav-sidenav__tools" role="list">
+            <li class="nav-sidenav__item">
+              <a href="#" class="nav-sidenav__tool-link nav-sidenav__tool-link--active" aria-current="page" aria-label="Maestro de apartamentos">
+                <span class="nav-sidenav__tool-icon" aria-hidden="true">
+                  <svg class="svg svg--md" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+                    <rect x="2" y="2" width="20" height="20" fill="#d4d4d4"/>
+                    <rect x="6" y="10" width="5" height="9" fill="#8c8c8c"/>
+                    <rect x="13" y="6" width="5" height="13" fill="#8c8c8c"/>
+                  </svg>
+                </span>
+                <span class="nav-sidenav__tool-label">Maestro de apartamentos</span>
+              </a>
+            </li>
+            <li class="nav-sidenav__item">
+              <a href="#" class="nav-sidenav__tool-link" aria-label="Sincronizador de contactos">
+                <span class="nav-sidenav__tool-icon" aria-hidden="true">
+                  <svg class="svg svg--md" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+                    <rect x="2" y="2" width="20" height="20" fill="#d4d4d4"/>
+                    <rect x="6" y="10" width="5" height="9" fill="#8c8c8c"/>
+                    <rect x="13" y="6" width="5" height="13" fill="#8c8c8c"/>
+                  </svg>
+                </span>
+                <span class="nav-sidenav__tool-label">Sincronizador de contactos</span>
+              </a>
+            </li>
+          </ul>
+          <footer class="nav-sidenav__footer">
+            <button class="nav-sidenav__collapse-btn" type="button" aria-label="Expandir menú lateral" aria-expanded="false">
+              <span class="nav-sidenav__collapse-icon" aria-hidden="true">
+                <svg class="svg svg--sm" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none">
+                  <polyline points="5,4 11,10 5,16"  stroke="#4a4a4a" stroke-width="2" stroke-linecap="square"/>
+                  <polyline points="10,4 16,10 10,16" stroke="#4a4a4a" stroke-width="2" stroke-linecap="square"/>
+                </svg>
+              </span>
+              <span class="nav-sidenav__collapse-label">Colapsar menú</span>
+            </button>
+          </footer>
+        </nav>
+      </div>
+
+    </div>
+  </div>
+
+</div>

--- a/frontend/src/app/pages/hoja-estilos/secciones/organismos/organismos.ts
+++ b/frontend/src/app/pages/hoja-estilos/secciones/organismos/organismos.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-ds-organismos',
+  templateUrl: './organismos.html',
+  standalone: true,
+})
+export class DsOrganismosComponent {}

--- a/frontend/src/app/pages/hoja-estilos/secciones/tipografia/tipografia.html
+++ b/frontend/src/app/pages/hoja-estilos/secciones/tipografia/tipografia.html
@@ -1,0 +1,226 @@
+<div class="ds-section">
+
+  <div class="ds-section__header">
+    <h2 class="ds-section__title">Tipografía</h2>
+    <p class="ds-section__desc">
+      Fuente <strong>Archivo</strong> (variable font 100–900). Escala definida desde Figma.
+      Display 800 → Heading 700 → Body / Label / H4 500 → Caption 400.
+    </p>
+  </div>
+
+  <!-- Display -->
+  <div class="ds-block">
+    <p class="ds-block__label">Display — weight 800</p>
+    <div class="ds-block__body">
+
+      <div class="ds-type-specimen">
+        <p class="ds-type-specimen__sample"
+           style="font-size:var(--font-size-display-2xl);font-weight:var(--font-weight-display);line-height:1.1">
+          Stay Sidekick
+        </p>
+        <div class="ds-type-specimen__meta">
+          <span class="ds-chip">display-2xl</span>
+          <span class="ds-chip">64px · 800</span>
+        </div>
+      </div>
+
+      <div class="ds-type-specimen">
+        <p class="ds-type-specimen__sample"
+           style="font-size:var(--font-size-display-xl);font-weight:var(--font-weight-display);line-height:1.1">
+          Stay Sidekick
+        </p>
+        <div class="ds-type-specimen__meta">
+          <span class="ds-chip">display-xl</span>
+          <span class="ds-chip">48px · 800</span>
+        </div>
+      </div>
+
+      <div class="ds-type-specimen">
+        <p class="ds-type-specimen__sample"
+           style="font-size:var(--font-size-display-lg);font-weight:var(--font-weight-display);line-height:1.1">
+          Stay Sidekick
+        </p>
+        <div class="ds-type-specimen__meta">
+          <span class="ds-chip">display-lg</span>
+          <span class="ds-chip">36px · 800</span>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- Headings -->
+  <div class="ds-block">
+    <p class="ds-block__label">Headings — weight 700 (H4 → 500)</p>
+    <div class="ds-block__body">
+
+      <div class="ds-type-specimen">
+        <h1 class="ds-type-specimen__sample">Gestión de alojamientos</h1>
+        <div class="ds-type-specimen__meta">
+          <span class="ds-chip">h1</span>
+          <span class="ds-chip">36px · 700</span>
+        </div>
+      </div>
+
+      <div class="ds-type-specimen">
+        <h2 class="ds-type-specimen__sample">Maestro de apartamentos</h2>
+        <div class="ds-type-specimen__meta">
+          <span class="ds-chip">h2</span>
+          <span class="ds-chip">32px · 700</span>
+        </div>
+      </div>
+
+      <div class="ds-type-specimen">
+        <h3 class="ds-type-specimen__sample">Sincronizador de contactos</h3>
+        <div class="ds-type-specimen__meta">
+          <span class="ds-chip">h3</span>
+          <span class="ds-chip">24px · 700</span>
+        </div>
+      </div>
+
+      <div class="ds-type-specimen">
+        <h4 class="ds-type-specimen__sample">Configuración de la herramienta</h4>
+        <div class="ds-type-specimen__meta">
+          <span class="ds-chip">h4</span>
+          <span class="ds-chip">20px · 500</span>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- Body -->
+  <div class="ds-block">
+    <p class="ds-block__label">Body — weight 500</p>
+    <div class="ds-block__body">
+
+      <div class="ds-type-specimen">
+        <p class="ds-type-specimen__sample"
+           style="font-size:var(--font-size-body-xl);font-weight:var(--font-weight-body);line-height:1.5">
+          El sistema centraliza la gestión de herramientas del alojamiento.
+        </p>
+        <div class="ds-type-specimen__meta">
+          <span class="ds-chip">body-xl</span>
+          <span class="ds-chip">18px · 500</span>
+        </div>
+      </div>
+
+      <div class="ds-type-specimen">
+        <p class="ds-type-specimen__sample"
+           style="font-size:var(--font-size-body-lg);font-weight:var(--font-weight-body);line-height:1.5">
+          El sistema centraliza la gestión de herramientas del alojamiento.
+        </p>
+        <div class="ds-type-specimen__meta">
+          <span class="ds-chip">body-lg</span>
+          <span class="ds-chip">16px · 500</span>
+        </div>
+      </div>
+
+      <div class="ds-type-specimen">
+        <p class="ds-type-specimen__sample"
+           style="font-size:var(--font-size-body-md);font-weight:var(--font-weight-body);line-height:1.5">
+          El sistema centraliza la gestión de herramientas del alojamiento.
+        </p>
+        <div class="ds-type-specimen__meta">
+          <span class="ds-chip">body-md</span>
+          <span class="ds-chip">14px · 500</span>
+        </div>
+      </div>
+
+      <div class="ds-type-specimen">
+        <p class="ds-type-specimen__sample"
+           style="font-size:var(--font-size-body-sm);font-weight:var(--font-weight-body);line-height:1.5">
+          El sistema centraliza la gestión de herramientas del alojamiento.
+        </p>
+        <div class="ds-type-specimen__meta">
+          <span class="ds-chip">body-sm</span>
+          <span class="ds-chip">12px · 500</span>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- Label -->
+  <div class="ds-block">
+    <p class="ds-block__label">Label — weight 500</p>
+    <div class="ds-block__body">
+
+      <div class="ds-type-specimen">
+        <p class="ds-type-specimen__sample"
+           style="font-size:var(--font-size-label-lg);font-weight:var(--font-weight-body);line-height:1.4">
+          Etiqueta de campo de formulario
+        </p>
+        <div class="ds-type-specimen__meta">
+          <span class="ds-chip">label-lg</span>
+          <span class="ds-chip">14px · 500</span>
+        </div>
+      </div>
+
+      <div class="ds-type-specimen">
+        <p class="ds-type-specimen__sample"
+           style="font-size:var(--font-size-label-md);font-weight:var(--font-weight-body);line-height:1.4">
+          Etiqueta de campo de formulario
+        </p>
+        <div class="ds-type-specimen__meta">
+          <span class="ds-chip">label-md</span>
+          <span class="ds-chip">12px · 500</span>
+        </div>
+      </div>
+
+      <div class="ds-type-specimen">
+        <p class="ds-type-specimen__sample"
+           style="font-size:0.6875rem;font-weight:var(--font-weight-body);line-height:1.4">
+          Etiqueta de campo de formulario
+        </p>
+        <div class="ds-type-specimen__meta">
+          <span class="ds-chip">label-sm</span>
+          <span class="ds-chip">11px · 500</span>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- Caption -->
+  <div class="ds-block">
+    <p class="ds-block__label">Caption — weight 400</p>
+    <div class="ds-block__body">
+
+      <div class="ds-type-specimen">
+        <p class="ds-type-specimen__sample"
+           style="font-size:var(--font-size-caption-md);font-weight:var(--font-weight-caption);line-height:1.4">
+          Texto de ayuda o descripción secundaria
+        </p>
+        <div class="ds-type-specimen__meta">
+          <span class="ds-chip">caption-md</span>
+          <span class="ds-chip">12px · 400</span>
+        </div>
+      </div>
+
+      <div class="ds-type-specimen">
+        <p class="ds-type-specimen__sample"
+           style="font-size:0.6875rem;font-weight:var(--font-weight-caption);line-height:1.4">
+          Texto de ayuda o descripción secundaria
+        </p>
+        <div class="ds-type-specimen__meta">
+          <span class="ds-chip">caption-sm</span>
+          <span class="ds-chip">11px · 400</span>
+        </div>
+      </div>
+
+      <div class="ds-type-specimen">
+        <p class="ds-type-specimen__sample"
+           style="font-size:0.625rem;font-weight:var(--font-weight-caption);line-height:1.4">
+          Texto de ayuda o descripción secundaria
+        </p>
+        <div class="ds-type-specimen__meta">
+          <span class="ds-chip">caption-xs</span>
+          <span class="ds-chip">10px · 400</span>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+</div>

--- a/frontend/src/app/pages/hoja-estilos/secciones/tipografia/tipografia.ts
+++ b/frontend/src/app/pages/hoja-estilos/secciones/tipografia/tipografia.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-ds-tipografia',
+  templateUrl: './tipografia.html',
+  standalone: true,
+})
+export class DsTipografiaComponent {}

--- a/frontend/src/styles/components/_hoja-estilos.scss
+++ b/frontend/src/styles/components/_hoja-estilos.scss
@@ -235,6 +235,24 @@ $_ds-nav-width: 200px;
 }
 
 // -------------------------------------------------------------------------
+// Specimen modificador para campos de formulario — ancho mínimo contenido
+// -------------------------------------------------------------------------
+// Modificadores de ancho para specimens de formulario
+// El mixin centraliza la regla repetida
+@mixin _ds-specimen-form($min-width) {
+  min-width: $min-width;
+
+  .ds-specimen__preview,
+  .form-field {
+    width: 100%;
+  }
+}
+
+.ds-specimen--form      { @include _ds-specimen-form(260px); }
+.ds-specimen--form-wide { @include _ds-specimen-form(360px); }
+.ds-specimen--form-xl   { @include _ds-specimen-form(420px); }
+
+// -------------------------------------------------------------------------
 // Divider
 // -------------------------------------------------------------------------
 .ds-divider {
@@ -262,7 +280,6 @@ $_ds-nav-width: 200px;
     height: auto;
   }
 
-  .nav-sidenav {
-    height: 280px;
-  }
+  // Altura explícita para que el sidenav sea visible en la preview
+  .nav-sidenav { height: 280px; }
 }

--- a/frontend/src/styles/components/_hoja-estilos.scss
+++ b/frontend/src/styles/components/_hoja-estilos.scss
@@ -1,0 +1,268 @@
+// =============================================================================
+// COMPONENTS: HOJA DE ESTILOS (Design System)
+// Layout y estilos de la página de documentación de componentes
+//
+// BEM:
+//   .ds-layout
+//     .ds-nav              (nav secundaria)
+//       .ds-nav__title
+//       .ds-nav__list
+//       .ds-nav__item
+//       .ds-nav__link
+//       .ds-nav__dot
+//     .ds-content          (área de contenido)
+//   .ds-section            (sección principal)
+//     .ds-section__header
+//     .ds-section__title
+//     .ds-section__desc
+//   .ds-block              (subsección)
+//     .ds-block__label
+//     .ds-block__body
+//   .ds-row                (fila horizontal de specimens)
+//   .ds-specimen           (muestra individual)
+//     .ds-specimen__label
+//     .ds-specimen__preview
+//     .ds-specimen__meta
+//   .ds-type-specimen      (muestra tipográfica full-width)
+//     .ds-type-specimen__sample
+//     .ds-type-specimen__meta
+//   .ds-chip               (tag de metadatos)
+//   .ds-divider            (separador visual)
+//   .ds-organism-preview   (caja contenedora para organismos)
+// =============================================================================
+
+$_ds-nav-width: 200px;
+
+// -------------------------------------------------------------------------
+// Layout — nav secundaria + contenido
+// -------------------------------------------------------------------------
+.ds-layout {
+  display: flex;
+  min-height: calc(100vh - #{$header-height});
+}
+
+// -------------------------------------------------------------------------
+// Nav secundaria — sticky dentro del área de contenido
+// -------------------------------------------------------------------------
+.ds-nav {
+  flex-shrink: 0;
+  width: $_ds-nav-width;
+  position: sticky;
+  top: $header-height;
+  height: calc(100vh - #{$header-height});
+  overflow-y: auto;
+  border-right: $border-width $border-style $color-border;
+  background-color: $color-surface;
+  padding: $space-4 0;
+
+  &__title {
+    @include text-label-sm;
+    color: $color-text-secondary;
+    padding: 0 $space-4 $space-3;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  &__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  &__link {
+    display: flex;
+    align-items: center;
+    gap: $space-3;
+    width: 100%;
+    padding: $space-3 $space-4;
+    text-decoration: none;
+    color: $color-text-primary;
+    @include text-label-md;
+    transition: background-color var(--transition-base);
+
+    &:hover {
+      background-color: $color-gray-100;
+    }
+
+    &:focus-visible {
+      outline: 2px solid $color-gray-800;
+      outline-offset: -2px;
+    }
+
+    &--active {
+      background-color: $color-gray-200;
+      font-weight: $font-weight-heading;
+    }
+  }
+
+  &__dot {
+    width: $space-2;
+    height: $space-2;
+    border-radius: 50%;
+    background-color: $color-gray-400;
+    flex-shrink: 0;
+  }
+}
+
+// -------------------------------------------------------------------------
+// Contenido principal
+// -------------------------------------------------------------------------
+.ds-content {
+  flex: 1 1 auto;
+  overflow: auto;
+  padding: $space-8;
+  max-width: 860px;
+}
+
+// -------------------------------------------------------------------------
+// Section — grupo principal (Átomos, Moléculas…)
+// -------------------------------------------------------------------------
+.ds-section {
+  &__header {
+    margin-bottom: $space-8;
+    padding-bottom: $space-4;
+    border-bottom: 2px solid $color-gray-800;
+  }
+
+  &__title {
+    @include text-h2;
+    color: $color-text-primary;
+    margin-bottom: $space-2;
+  }
+
+  &__desc {
+    @include text-body-md;
+    color: $color-text-secondary;
+  }
+}
+
+// -------------------------------------------------------------------------
+// Block — subsección dentro de una sección
+// -------------------------------------------------------------------------
+.ds-block {
+  margin-bottom: $space-10;
+
+  &__label {
+    @include text-label-sm;
+    color: $color-text-secondary;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: $space-4;
+    padding-bottom: $space-2;
+    border-bottom: $border-width $border-style $color-border;
+  }
+
+  &__body {
+    display: flex;
+    flex-direction: column;
+    gap: $space-4;
+  }
+}
+
+// -------------------------------------------------------------------------
+// Row — fila de specimens en línea
+// -------------------------------------------------------------------------
+.ds-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: $space-6;
+}
+
+// -------------------------------------------------------------------------
+// Specimen — muestra individual con label y preview
+// -------------------------------------------------------------------------
+.ds-specimen {
+  display: flex;
+  flex-direction: column;
+  gap: $space-2;
+
+  &__label {
+    @include text-caption-md;
+    color: $color-text-secondary;
+  }
+
+  &__preview {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+  }
+
+  &__meta {
+    @include text-caption-xs;
+    color: $color-text-disabled;
+    font-family: monospace;
+  }
+}
+
+// -------------------------------------------------------------------------
+// Type specimen — muestra tipográfica full-width con metadatos
+// -------------------------------------------------------------------------
+.ds-type-specimen {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: $space-6;
+  padding: $space-3 0;
+  border-bottom: $border-width $border-style $color-border;
+
+  &__sample {
+    flex: 1;
+    margin: 0;
+    color: $color-text-primary;
+  }
+
+  &__meta {
+    flex-shrink: 0;
+    display: flex;
+    gap: $space-2;
+    align-items: center;
+  }
+}
+
+// -------------------------------------------------------------------------
+// Chip — tag de metadatos monoespaciado
+// -------------------------------------------------------------------------
+.ds-chip {
+  display: inline-block;
+  padding: $space-1 $space-2;
+  border: $border-width $border-style $color-border;
+  background-color: $color-gray-100;
+  @include text-caption-xs;
+  color: $color-text-secondary;
+  font-family: monospace;
+  white-space: nowrap;
+}
+
+// -------------------------------------------------------------------------
+// Divider
+// -------------------------------------------------------------------------
+.ds-divider {
+  margin: $space-8 0;
+  border: none;
+  border-top: $border-width $border-style $color-border;
+}
+
+// -------------------------------------------------------------------------
+// Organism preview — caja acotada para demos de organismos
+// -------------------------------------------------------------------------
+.ds-organism-preview {
+  border: $border-width $border-style $color-border;
+  overflow: hidden;
+  background-color: $color-surface;
+  position: relative;
+
+  // Anula position:sticky/fixed de los organismos dentro de la preview
+  .header,
+  .nav-sidenav {
+    position: relative;
+    top: auto;
+    left: auto;
+    width: 100%;
+    height: auto;
+  }
+
+  .nav-sidenav {
+    height: 280px;
+  }
+}

--- a/frontend/src/styles/components/_index.scss
+++ b/frontend/src/styles/components/_index.scss
@@ -18,3 +18,4 @@
 @import 'tabla-crud';
 @import 'maestro-apartamentos';
 @import 'sincronizador-contactos';
+@import 'hoja-estilos';


### PR DESCRIPTION
Añade la página /menu/hoja-estilos como última entrada del sidenav, con una nav secundaria (ds-nav) para navegar entre cuatro secciones: Tipografía (escala completa display/heading/body/label/caption con metadatos), Átomos (botones primario/secundario en todos sus tamaños, badges, SVG sizes y logo), Moléculas (input, select, textarea, editor enriquecido estilo GitHub, radio y checkbox con estados de error) y Organismos (header y nav-sidenav en preview acotada con estados expandido y colapsado). Los componentes de la hoja de estilos se cargan en lazy loading para no inflar el bundle inicial. Estilos BEM/ITCSS con bloque ds-* en la capa components.