### PR TITLE
feat: añadir herramienta de notificaciones de check-in tardíos

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -45,14 +45,16 @@ def create_app(config_class: type = Config) -> Flask:
         import app.models  # noqa: F401
 
     # ── Blueprints ───────────────────────────────────────────────────────
-    from app.routes.formulario_solicitud import formulario_solicitud_bp  # noqa: E402
-    from app.auth.routes import auth_bp                                  # noqa: E402
-    from app.apartamentos.routes import apartamentos_bp                  # noqa: E402
-    from app.routes.contactos import contactos_bp                        # noqa: E402
+    from app.routes.formulario_solicitud import formulario_solicitud_bp      # noqa: E402
+    from app.auth.routes import auth_bp                                      # noqa: E402
+    from app.apartamentos.routes import apartamentos_bp                      # noqa: E402
+    from app.routes.contactos import contactos_bp                            # noqa: E402
+    from app.notificaciones.routes import notificaciones_bp                  # noqa: E402
     app.register_blueprint(formulario_solicitud_bp)
     app.register_blueprint(auth_bp)
     app.register_blueprint(apartamentos_bp)
     app.register_blueprint(contactos_bp)
+    app.register_blueprint(notificaciones_bp)
 
     # ── Error handlers ───────────────────────────────────────────────────
     @app.errorhandler(429)

--- a/backend/app/common/notifications/gmail.py
+++ b/backend/app/common/notifications/gmail.py
@@ -23,20 +23,56 @@ _SMTP_PORT = 587
 _TIMEOUT = 10
 
 
-def _build_message(clean_data: dict) -> EmailMessage:
-    """Construye el EmailMessage con los datos sanitizados del formulario."""
-    sender = current_app.config["GMAIL_USER"]
-    recipient = current_app.config["MAIL_RECIPIENT"]
+def send_via_smtp(to: str, subject: str, body: str) -> tuple[bool, str | None]:
+    """Envía un email de texto plano vía Gmail SMTP.
+
+    Función de bajo nivel reutilizable por cualquier módulo que necesite
+    enviar emails. Devuelve ``(True, None)`` si el envío fue exitoso o
+    ``(False, mensaje_error)`` si falló.
+    """
+    user = current_app.config.get("GMAIL_USER", "")
+    password = current_app.config.get("GMAIL_APP_PASSWORD", "")
+
+    if not user or not password:
+        return False, "Gmail SMTP no configurado (GMAIL_USER / GMAIL_APP_PASSWORD)."
 
     msg = EmailMessage()
-    msg["Subject"] = (
-        f"[Stay Sidekick] Nueva solicitud de {clean_data.get('company_name', 'N/A')}"
-    )
-    msg["From"] = sender
-    msg["To"] = recipient
+    msg["Subject"] = subject
+    msg["From"] = user
+    msg["To"] = to
+    msg.set_content(body)
 
+    try:
+        with smtplib.SMTP(_SMTP_HOST, _SMTP_PORT, timeout=_TIMEOUT) as server:
+            server.ehlo()
+            server.starttls()
+            server.ehlo()
+            server.login(user, password)
+            server.send_message(msg)
+        return True, None
+
+    except smtplib.SMTPException as exc:
+        logger.exception("Error al enviar email vía Gmail SMTP")
+        return False, f"Error al enviar el email: {exc}"
+
+
+def send_contact_email(clean_data: dict) -> bool:
+    """Envía el email de notificación de solicitud de contacto por Gmail SMTP.
+
+    Returns
+    -------
+    bool
+        ``True`` si el email se envió correctamente.
+    """
+    if not current_app.config.get("GMAIL_USER") or not current_app.config.get("GMAIL_APP_PASSWORD"):
+        logger.warning(
+            "Gmail SMTP no configurado (GMAIL_USER / GMAIL_APP_PASSWORD vacíos). "
+            "El email de notificación no se enviará."
+        )
+        return False
+
+    subject = f"[Stay Sidekick] Nueva solicitud de {clean_data.get('company_name', 'N/A')}"
     is_member = "Sí" if clean_data.get("is_member") else "No"
-
     body = (
         "Se ha recibido una nueva solicitud desde el formulario de contacto.\n"
         "\n"
@@ -50,45 +86,16 @@ def _build_message(clean_data: dict) -> EmailMessage:
         "Mensaje:\n"
         f"{clean_data.get('message', '') or '(sin mensaje)'}\n"
     )
-    msg.set_content(body)
-    return msg
 
-
-def send_contact_email(clean_data: dict) -> bool:
-    """Envía el email de notificación por Gmail SMTP.
-
-    Returns
-    -------
-    bool
-        ``True`` si el email se envió correctamente.
-    """
-    user = current_app.config.get("GMAIL_USER", "")
-    password = current_app.config.get("GMAIL_APP_PASSWORD", "")
-
-    if not user or not password:
-        logger.warning(
-            "Gmail SMTP no configurado (GMAIL_USER / GMAIL_APP_PASSWORD vacíos). "
-            "El email de notificación no se enviará."
-        )
-        return False
-
-    msg = _build_message(clean_data)
-
-    try:
-        with smtplib.SMTP(_SMTP_HOST, _SMTP_PORT, timeout=_TIMEOUT) as server:
-            server.ehlo()
-            server.starttls()
-            server.ehlo()
-            server.login(user, password)
-            server.send_message(msg)
-
+    ok, _ = send_via_smtp(
+        to=current_app.config["MAIL_RECIPIENT"],
+        subject=subject,
+        body=body,
+    )
+    if ok:
         logger.info(
             "Email enviado a %s para solicitud de %s",
             current_app.config["MAIL_RECIPIENT"],
             clean_data.get("company_name"),
         )
-        return True
-
-    except smtplib.SMTPException:
-        logger.exception("Error al enviar email vía Gmail SMTP")
-        return False
+    return ok

--- a/backend/app/notificaciones/routes.py
+++ b/backend/app/notificaciones/routes.py
@@ -1,0 +1,102 @@
+"""Blueprint de notificaciones para check-in tardíos.
+
+Rutas (todas requieren JWT):
+- GET  /api/notificaciones/checkin-tardio/status  → estado: Gmail, PMS, check-ins hoy, apartamentos
+- POST /api/notificaciones/checkin-tardio/xlsx    → parsea XLSX, devuelve check-ins de hoy (en memoria)
+- POST /api/notificaciones/checkin-tardio/enviar  → envía email de notificación (destinatario + mensaje)
+"""
+
+import logging
+
+from flask import Blueprint, g, jsonify, request
+
+from app.extensions import limiter
+from app.security.jwt import jwt_required
+from app.notificaciones import service
+
+logger = logging.getLogger(__name__)
+
+notificaciones_bp = Blueprint("notificaciones", __name__)
+
+
+def _empresa_id() -> str:
+    """Extrae el empresa_id del JWT."""
+    return g.jwt_claims["empresa_id"]
+
+
+# ── Status ────────────────────────────────────────────────────────────────
+
+
+@notificaciones_bp.route("/api/notificaciones/checkin-tardio/status", methods=["GET"])
+@jwt_required
+def get_status():
+    """Estado de la herramienta: Gmail configurado, PMS, apartamentos y check-ins de hoy."""
+    data = service.get_status(_empresa_id())
+    return jsonify({"ok": True, **data}), 200
+
+
+# ── XLSX ──────────────────────────────────────────────────────────────────
+
+
+@notificaciones_bp.route("/api/notificaciones/checkin-tardio/xlsx", methods=["POST"])
+@limiter.limit("20/hour")
+@jwt_required
+def upload_xlsx():
+    """Parsea un XLSX de reservas y devuelve los check-ins de hoy.
+
+    Espera el campo ``file`` con el archivo .xlsx.
+    Los datos se procesan en memoria y no se persisten (RGPD).
+    """
+    if "file" not in request.files:
+        return jsonify({"ok": False, "errors": ["Se esperaba un campo 'file' con el archivo."]}), 400
+
+    f = request.files["file"]
+    if not f.filename or not f.filename.lower().endswith(".xlsx"):
+        return jsonify({"ok": False, "errors": ["El archivo debe tener extensión .xlsx."]}), 400
+
+    file_bytes = f.read()
+    if not file_bytes:
+        return jsonify({"ok": False, "errors": ["El archivo está vacío."]}), 400
+
+    checkins, advertencias = service.parse_checkins_xlsx(file_bytes)
+
+    result: dict = {"ok": True, "checkins": checkins}
+    if advertencias:
+        result["warnings"] = advertencias
+    return jsonify(result), 200
+
+
+# ── Envío de notificación ─────────────────────────────────────────────────
+
+
+@notificaciones_bp.route("/api/notificaciones/checkin-tardio/enviar", methods=["POST"])
+@limiter.limit("30/hour")
+@jwt_required
+def enviar_notificacion():
+    """Envía un email de notificación de check-in tardío.
+
+    Body JSON esperado:
+    {
+        "destinatario": "correo@ejemplo.com",
+        "asunto": "Recordatorio de check-in",   // opcional
+        "mensaje": "Texto del email..."
+    }
+    """
+    json_data = request.get_json(silent=True)
+    if not json_data:
+        return jsonify({"ok": False, "errors": ["Se esperaba un cuerpo JSON."]}), 400
+
+    destinatario = (json_data.get("destinatario") or "").strip()
+    asunto = (json_data.get("asunto") or "Recordatorio de check-in").strip()
+    mensaje = (json_data.get("mensaje") or "").strip()
+
+    if not destinatario:
+        return jsonify({"ok": False, "errors": ["El campo 'destinatario' es obligatorio."]}), 422
+    if not mensaje:
+        return jsonify({"ok": False, "errors": ["El campo 'mensaje' no puede estar vacío."]}), 422
+
+    ok, error = service.enviar_notificacion(destinatario, asunto, mensaje)
+    if not ok:
+        return jsonify({"ok": False, "errors": [error]}), 400
+
+    return jsonify({"ok": True}), 200

--- a/backend/app/notificaciones/service.py
+++ b/backend/app/notificaciones/service.py
@@ -8,23 +8,17 @@ Orquesta:
 """
 
 import logging
-import smtplib
 from datetime import date
-from email.message import EmailMessage
 
 from flask import current_app
 
 from app.apartamentos import repository as apt_repo
 from app.common.crypto import decrypt
+from app.common.notifications.gmail import send_via_smtp
 from app.common.xlsx_reservas import parse_xlsx_reservas
-from app.pms.smoobu import SmoobuReservationClient
-from app.pms.beds24 import Beds24ReservationClient
+from app.pms.factory import build_pms_client
 
 logger = logging.getLogger(__name__)
-
-_SMTP_HOST = "smtp.gmail.com"
-_SMTP_PORT = 587
-_SMTP_TIMEOUT = 10
 
 
 # ── Status ────────────────────────────────────────────────────────────────
@@ -43,14 +37,12 @@ def get_status(empresa_id: str) -> dict:
         and current_app.config.get("GMAIL_APP_PASSWORD")
     )
 
-    # Apartamentos activos del maestro
     apts = apt_repo.list_by_empresa(empresa_id)
     apartamentos = [
         {"id": str(a.id), "nombre": a.nombre, "ciudad": a.ciudad}
         for a in apts
     ]
 
-    # Reservas de hoy del PMS (si está configurado)
     reservas_pms: list[dict] = []
     pms_configurado = False
     pms_error: str | None = None
@@ -61,7 +53,7 @@ def get_status(empresa_id: str) -> dict:
         if api_key:
             pms_configurado = True
             try:
-                client = _build_pms_client(
+                client = build_pms_client(
                     pms_config.proveedor, api_key, pms_config.endpoint
                 )
                 hoy = date.today().isoformat()
@@ -71,7 +63,7 @@ def get_status(empresa_id: str) -> dict:
                 logger.warning(
                     "Error al obtener reservas PMS para notificaciones: %s", exc
                 )
-                pms_error = f"No se pudieron cargar las reservas del PMS: {exc}"
+                pms_error = "No se pudieron cargar las reservas del PMS."
 
     return {
         "gmail_configurado": gmail_ok,
@@ -93,7 +85,7 @@ def parse_checkins_xlsx(file_bytes: bytes) -> tuple[list[dict], list[str]]:
     Los datos se procesan en memoria y no se persisten (cumplimiento RGPD).
     """
     reservas, errores = parse_xlsx_reservas(file_bytes)
-    hoy = date.today().isoformat()  # YYYY-MM-DD
+    hoy = date.today().isoformat()
 
     tiene_fechas = any(r.checkin for r in reservas)
     if tiene_fechas:
@@ -113,50 +105,21 @@ def parse_checkins_xlsx(file_bytes: bytes) -> tuple[list[dict], list[str]]:
 def enviar_notificacion(
     destinatario: str, asunto: str, mensaje: str
 ) -> tuple[bool, str | None]:
-    """Envía un email de notificación vía Gmail SMTP.
-
-    Returns
-    -------
-    tuple[bool, str | None]
-        (exito, mensaje_error). Si exito es True, mensaje_error es None.
-    """
-    user = current_app.config.get("GMAIL_USER", "")
-    password = current_app.config.get("GMAIL_APP_PASSWORD", "")
-
-    if not user or not password:
-        return False, "Gmail SMTP no está configurado (GMAIL_USER / GMAIL_APP_PASSWORD)."
-
-    msg = EmailMessage()
-    msg["Subject"] = asunto
-    msg["From"] = user
-    msg["To"] = destinatario
-    msg.set_content(mensaje)
-
-    try:
-        with smtplib.SMTP(_SMTP_HOST, _SMTP_PORT, timeout=_SMTP_TIMEOUT) as server:
-            server.ehlo()
-            server.starttls()
-            server.ehlo()
-            server.login(user, password)
-            server.send_message(msg)
-
+    """Envía un email de notificación vía Gmail SMTP."""
+    ok, error = send_via_smtp(destinatario, asunto, mensaje)
+    if ok:
         logger.info(
             "Notificación check-in tardío enviada a '%s' (asunto: '%s')",
             destinatario,
             asunto,
         )
-        return True, None
-
-    except smtplib.SMTPException as exc:
-        logger.exception("Error al enviar notificación de check-in tardío")
-        return False, f"Error al enviar el email: {exc}"
+    return ok, error
 
 
 # ── Helpers privados ──────────────────────────────────────────────────────
 
 
 def _reserva_a_dict(r) -> dict:
-    """Serializa una ReservaEstandar a dict JSON-serializable."""
     return {
         "nombre": r.nombre_raw,
         "apartamento": r.nombre_apartamento,
@@ -165,12 +128,3 @@ def _reserva_a_dict(r) -> dict:
         "checkin": r.checkin,
         "checkout": r.checkout,
     }
-
-
-def _build_pms_client(proveedor: str, api_key: str, endpoint: str | None):
-    """Instancia el adaptador PMS correcto según el proveedor configurado."""
-    if proveedor == "smoobu":
-        return SmoobuReservationClient(api_key)
-    if proveedor == "beds24":
-        return Beds24ReservationClient(api_key, endpoint)
-    raise ValueError(f"Proveedor PMS no soportado para reservas: {proveedor!r}")

--- a/backend/app/notificaciones/service.py
+++ b/backend/app/notificaciones/service.py
@@ -1,0 +1,176 @@
+"""Servicio de notificaciones para check-in tardíos.
+
+Orquesta:
+- Lectura del maestro de apartamentos (activos de la empresa).
+- Obtención de reservas de hoy desde el PMS API configurado.
+- Parseo de XLSX subido por el usuario (procesado en memoria, no persiste — RGPD).
+- Envío de email de notificación vía Gmail SMTP con destino y mensaje personalizables.
+"""
+
+import logging
+import smtplib
+from datetime import date
+from email.message import EmailMessage
+
+from flask import current_app
+
+from app.apartamentos import repository as apt_repo
+from app.common.crypto import decrypt
+from app.common.xlsx_reservas import parse_xlsx_reservas
+from app.pms.smoobu import SmoobuReservationClient
+from app.pms.beds24 import Beds24ReservationClient
+
+logger = logging.getLogger(__name__)
+
+_SMTP_HOST = "smtp.gmail.com"
+_SMTP_PORT = 587
+_SMTP_TIMEOUT = 10
+
+
+# ── Status ────────────────────────────────────────────────────────────────
+
+
+def get_status(empresa_id: str) -> dict:
+    """Devuelve el estado de la herramienta para la empresa.
+
+    Incluye:
+    - Si Gmail SMTP está configurado (GMAIL_USER + GMAIL_APP_PASSWORD).
+    - Si hay PMS configurado y las reservas de check-in de hoy.
+    - Lista de apartamentos activos del maestro.
+    """
+    gmail_ok = bool(
+        current_app.config.get("GMAIL_USER")
+        and current_app.config.get("GMAIL_APP_PASSWORD")
+    )
+
+    # Apartamentos activos del maestro
+    apts = apt_repo.list_by_empresa(empresa_id)
+    apartamentos = [
+        {"id": str(a.id), "nombre": a.nombre, "ciudad": a.ciudad}
+        for a in apts
+    ]
+
+    # Reservas de hoy del PMS (si está configurado)
+    reservas_pms: list[dict] = []
+    pms_configurado = False
+    pms_error: str | None = None
+
+    pms_config = apt_repo.get_pms_config(empresa_id)
+    if pms_config and pms_config.api_key_cifrada:
+        api_key = decrypt(pms_config.api_key_cifrada)
+        if api_key:
+            pms_configurado = True
+            try:
+                client = _build_pms_client(
+                    pms_config.proveedor, api_key, pms_config.endpoint
+                )
+                hoy = date.today().isoformat()
+                reservas = client.fetch_reservations(desde=hoy, hasta=hoy)
+                reservas_pms = [_reserva_a_dict(r) for r in reservas]
+            except Exception as exc:
+                logger.warning(
+                    "Error al obtener reservas PMS para notificaciones: %s", exc
+                )
+                pms_error = f"No se pudieron cargar las reservas del PMS: {exc}"
+
+    return {
+        "gmail_configurado": gmail_ok,
+        "pms_configurado": pms_configurado,
+        "pms_error": pms_error,
+        "apartamentos": apartamentos,
+        "reservas_pms": reservas_pms,
+    }
+
+
+# ── XLSX ──────────────────────────────────────────────────────────────────
+
+
+def parse_checkins_xlsx(file_bytes: bytes) -> tuple[list[dict], list[str]]:
+    """Parsea un XLSX y devuelve los check-ins de hoy.
+
+    Si el archivo contiene columna de fecha de check-in, filtra por hoy.
+    Si no tiene columna de fecha, devuelve todas las filas (con aviso).
+    Los datos se procesan en memoria y no se persisten (cumplimiento RGPD).
+    """
+    reservas, errores = parse_xlsx_reservas(file_bytes)
+    hoy = date.today().isoformat()  # YYYY-MM-DD
+
+    tiene_fechas = any(r.checkin for r in reservas)
+    if tiene_fechas:
+        reservas_hoy = [r for r in reservas if r.checkin == hoy]
+        if not reservas_hoy:
+            errores = [f"No hay check-ins para hoy ({hoy}) en el archivo."] + errores
+    else:
+        reservas_hoy = reservas
+        errores = ["El archivo no contiene columna de fecha — se muestran todas las filas."] + errores
+
+    return [_reserva_a_dict(r) for r in reservas_hoy], errores
+
+
+# ── Envío de email ────────────────────────────────────────────────────────
+
+
+def enviar_notificacion(
+    destinatario: str, asunto: str, mensaje: str
+) -> tuple[bool, str | None]:
+    """Envía un email de notificación vía Gmail SMTP.
+
+    Returns
+    -------
+    tuple[bool, str | None]
+        (exito, mensaje_error). Si exito es True, mensaje_error es None.
+    """
+    user = current_app.config.get("GMAIL_USER", "")
+    password = current_app.config.get("GMAIL_APP_PASSWORD", "")
+
+    if not user or not password:
+        return False, "Gmail SMTP no está configurado (GMAIL_USER / GMAIL_APP_PASSWORD)."
+
+    msg = EmailMessage()
+    msg["Subject"] = asunto
+    msg["From"] = user
+    msg["To"] = destinatario
+    msg.set_content(mensaje)
+
+    try:
+        with smtplib.SMTP(_SMTP_HOST, _SMTP_PORT, timeout=_SMTP_TIMEOUT) as server:
+            server.ehlo()
+            server.starttls()
+            server.ehlo()
+            server.login(user, password)
+            server.send_message(msg)
+
+        logger.info(
+            "Notificación check-in tardío enviada a '%s' (asunto: '%s')",
+            destinatario,
+            asunto,
+        )
+        return True, None
+
+    except smtplib.SMTPException as exc:
+        logger.exception("Error al enviar notificación de check-in tardío")
+        return False, f"Error al enviar el email: {exc}"
+
+
+# ── Helpers privados ──────────────────────────────────────────────────────
+
+
+def _reserva_a_dict(r) -> dict:
+    """Serializa una ReservaEstandar a dict JSON-serializable."""
+    return {
+        "nombre": r.nombre_raw,
+        "apartamento": r.nombre_apartamento,
+        "email": r.email,
+        "telefono": r.telefono,
+        "checkin": r.checkin,
+        "checkout": r.checkout,
+    }
+
+
+def _build_pms_client(proveedor: str, api_key: str, endpoint: str | None):
+    """Instancia el adaptador PMS correcto según el proveedor configurado."""
+    if proveedor == "smoobu":
+        return SmoobuReservationClient(api_key)
+    if proveedor == "beds24":
+        return Beds24ReservationClient(api_key, endpoint)
+    raise ValueError(f"Proveedor PMS no soportado para reservas: {proveedor!r}")

--- a/backend/app/pms/factory.py
+++ b/backend/app/pms/factory.py
@@ -1,0 +1,18 @@
+"""Factory de clientes PMS.
+
+Centraliza la instanciación del adaptador correcto según el proveedor
+configurado. Importado por cualquier módulo que necesite obtener reservas
+del PMS (google_contacts, notificaciones, etc.).
+"""
+
+from app.pms.beds24 import Beds24ReservationClient
+from app.pms.smoobu import SmoobuReservationClient
+
+
+def build_pms_client(proveedor: str, api_key: str, endpoint: str | None):
+    """Instancia el adaptador PMS correcto según el proveedor configurado."""
+    if proveedor == "smoobu":
+        return SmoobuReservationClient(api_key)
+    if proveedor == "beds24":
+        return Beds24ReservationClient(api_key, endpoint)
+    raise ValueError(f"Proveedor PMS no soportado para reservas: {proveedor!r}")

--- a/backend/app/services/google_contacts.py
+++ b/backend/app/services/google_contacts.py
@@ -21,8 +21,7 @@ from app.common.xlsx_reservas import parse_xlsx_reservas
 from app.extensions import db
 from app.models.integraciones import IntegracionGoogle
 from app.models.logs import ORIGEN_GOOGLE_CONTACTS, ESTADO_EXITO, ESTADO_ERROR, ESTADO_PARCIAL
-from app.pms.smoobu import SmoobuReservationClient
-from app.pms.beds24 import Beds24ReservationClient
+from app.pms.factory import build_pms_client
 from app.repositories import google_integration as repo
 from app.schemas.google_contacts import PreferenciasContactosSchema, SyncRangoSchema
 from app.services.csv_contacts import build_csv, _split_nombre, _format_display_name, _build_notas, _build_grupo
@@ -207,7 +206,7 @@ def sync_contacts(empresa_id: str, json_data: dict) -> tuple[dict | None, str | 
 
     # 3. Obtener reservas del PMS
     try:
-        pms_client = _build_pms_client(pms_config.proveedor, api_key_pms, pms_config.endpoint)
+        pms_client = build_pms_client(pms_config.proveedor, api_key_pms, pms_config.endpoint)
         desde_str = json_data.get("desde")
         hasta_str = json_data.get("hasta")
         reservas = pms_client.fetch_reservations(
@@ -298,7 +297,7 @@ def export_csv(empresa_id: str, json_data: dict) -> tuple[bytes | None, str | No
         return None, "No se pudo descifrar la API key del PMS."
 
     try:
-        pms_client = _build_pms_client(pms_config.proveedor, api_key_pms, pms_config.endpoint)
+        pms_client = build_pms_client(pms_config.proveedor, api_key_pms, pms_config.endpoint)
         desde_str = json_data.get("desde")
         hasta_str = json_data.get("hasta")
         reservas = pms_client.fetch_reservations(
@@ -417,15 +416,6 @@ def export_csv_from_xlsx(empresa_id: str, file_bytes: bytes) -> tuple[bytes | No
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────
-
-
-def _build_pms_client(proveedor: str, api_key: str, endpoint: str | None):
-    """Instancia el adaptador PMS correcto según el proveedor configurado."""
-    if proveedor == "smoobu":
-        return SmoobuReservationClient(api_key)
-    if proveedor == "beds24":
-        return Beds24ReservationClient(api_key, endpoint)
-    raise ValueError(f"Proveedor PMS no soportado para reservas: {proveedor!r}")
 
 
 def _build_contact_payload(reserva, prefs: dict, google_client: GooglePeopleClient) -> dict:

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -12,6 +12,13 @@ export const routes: Routes = [
       { path: '', component: MenuDefaultPageComponent },
       { path: 'maestro-apartamentos', component: MaestroApartamentosPageComponent },
       { path: 'sincronizador-contactos', component: SincronizadorContactosPageComponent },
+      {
+        path: 'notificaciones-checkin-tardio',
+        loadComponent: () =>
+          import('./pages/notificaciones-checkin-tardio/notificaciones-checkin-tardio').then(
+            m => m.NotificacionesCheckinTardioPageComponent
+          ),
+      },
     ],
   },
 ];

--- a/frontend/src/app/components/sidenav/sidenav.ts
+++ b/frontend/src/app/components/sidenav/sidenav.ts
@@ -10,8 +10,8 @@ interface Tool {
 
 const TOOLS: Tool[] = [
   { id: 'maestro-apartamentos', label: 'Maestro de apartamentos', route: '/menu/maestro-apartamentos' },
-  { id: 'sincronizador-contactos', label: 'Sincronizador de contactos', route: '/menu/sincronizador-contactos' },
-  { id: 'tool-3', label: 'Herramienta 3', route: null },
+  { id: 'sincronizador-contactos',       label: 'Sincronizador de contactos', route: '/menu/sincronizador-contactos'       },
+  { id: 'notificaciones-checkin-tardio', label: 'Notificaciones check-in',    route: '/menu/notificaciones-checkin-tardio' },
   { id: 'tool-4', label: 'Herramienta 4', route: null },
   { id: 'tool-5', label: 'Herramienta 5', route: null },
 ];

--- a/frontend/src/app/pages/notificaciones-checkin-tardio/notificaciones-checkin-tardio.html
+++ b/frontend/src/app/pages/notificaciones-checkin-tardio/notificaciones-checkin-tardio.html
@@ -282,20 +282,40 @@
           />
         </div>
 
-        <!-- Mensaje (editable) -->
+        <!-- Mensaje (editable) con botón de copiar -->
         <div class="form-group">
           <label class="form-label" for="notif-mensaje">
             Mensaje
           </label>
-          <textarea
-            id="notif-mensaje"
-            class="form-textarea notif-form__textarea"
-            rows="12"
-            placeholder="Escribe o genera el mensaje de notificación aquí…"
-            [disabled]="!gmailConfigurado()"
-            [(ngModel)]="mensaje"
-            name="mensaje"
-          ></textarea>
+          <div class="form-editor">
+            <div class="form-editor__header">
+              <div class="form-editor__tabs"></div>
+              <div class="form-editor__toolbar">
+                <button
+                  class="form-editor__tool"
+                  type="button"
+                  [disabled]="!mensaje"
+                  (click)="copiarMensaje()"
+                >
+                  @if (copiadoOk()) {
+                    Copiado
+                  } @else {
+                    Copiar
+                  }
+                </button>
+              </div>
+            </div>
+            <div class="form-editor__body">
+              <textarea
+                id="notif-mensaje"
+                class="form-textarea notif-form__textarea"
+                placeholder="Escribe o genera el mensaje de notificación aquí…"
+                [attr.disabled]="!gmailConfigurado() ? '' : null"
+                [(ngModel)]="mensaje"
+                name="mensaje"
+              ></textarea>
+            </div>
+          </div>
         </div>
 
         <!-- Acciones envío -->

--- a/frontend/src/app/pages/notificaciones-checkin-tardio/notificaciones-checkin-tardio.html
+++ b/frontend/src/app/pages/notificaciones-checkin-tardio/notificaciones-checkin-tardio.html
@@ -1,0 +1,335 @@
+<!-- Página: Notificaciones de check-in tardíos -->
+<div class="notif-checkin">
+
+  <!-- Cabecera -->
+  <header class="page-header">
+    <div class="page-header__start">
+      <h1 class="page-header__title">Notificaciones de check-in tardíos</h1>
+      <p class="page-header__desc">
+        Consulta los check-ins de hoy, importa el listado desde Excel y envía
+        un recordatorio personalizado por email a quien necesites.
+      </p>
+    </div>
+  </header>
+
+  @if (cargando()) {
+    <p class="notif-checkin__cargando" aria-live="polite">Cargando datos…</p>
+  } @else {
+
+    <!-- ── Sección 1: Estado del día (PMS) ───────────────────────────── -->
+    <section class="panel-seccion" aria-labelledby="titulo-estado-dia">
+      <h2 class="panel-seccion__titulo" id="titulo-estado-dia">
+        Check-ins de hoy
+      </h2>
+      <p class="panel-seccion__desc">
+        Reservas con entrada programada para hoy obtenidas desde tu PMS.
+      </p>
+
+      <div class="panel-seccion__body">
+
+        @if (!pmsConfigurado()) {
+          <p class="notif-checkin__aviso" role="note">
+            No hay PMS configurado. Configura tu API key en el apartado de
+            ajustes para obtener las reservas automáticamente.
+          </p>
+        } @else if (pmsError()) {
+          <p class="notif-checkin__aviso notif-checkin__aviso--error" role="alert">
+            {{ pmsError() }}
+          </p>
+        } @else if (reservasPms().length === 0) {
+          <p class="notif-checkin__aviso" role="note">
+            No hay check-ins registrados para hoy en el PMS.
+          </p>
+        } @else {
+          <table class="tabla-checkins" aria-label="Check-ins de hoy (PMS)">
+            <thead class="tabla-checkins__head">
+              <tr>
+                <th scope="col">Huésped</th>
+                <th scope="col">Apartamento</th>
+                <th scope="col">Email</th>
+                <th scope="col">Teléfono</th>
+                <th scope="col">Checkout</th>
+              </tr>
+            </thead>
+            <tbody class="tabla-checkins__body">
+              @for (r of reservasPms(); track r.nombre) {
+                <tr>
+                  <td>{{ r.nombre }}</td>
+                  <td>{{ r.apartamento ?? '—' }}</td>
+                  <td>{{ r.email ?? '—' }}</td>
+                  <td>{{ r.telefono ?? '—' }}</td>
+                  <td>{{ r.checkout ?? '—' }}</td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        }
+
+      </div>
+    </section>
+
+    <!-- ── Sección 2: Importar desde XLSX ────────────────────────────── -->
+    <section class="panel-seccion" aria-labelledby="titulo-xlsx">
+      <h2 class="panel-seccion__titulo" id="titulo-xlsx">
+        Importar reservas del día (XLSX)
+      </h2>
+      <p class="panel-seccion__desc">
+        Si tu PMS no tiene API, exporta el listado de reservas de hoy a Excel
+        y súbelo aquí. Los datos se procesan en servidor sin almacenarse (RGPD).
+        Columnas reconocidas: <code>nombre</code>, <code>email</code>,
+        <code>telefono</code>, <code>checkin</code>, <code>checkout</code>,
+        <code>apartamento</code>.
+      </p>
+
+      <div class="panel-seccion__body xlsx-import">
+
+        <!-- Selector de archivo -->
+        <div class="xlsx-import__selector">
+          <input
+            #xlsxInput
+            type="file"
+            accept=".xlsx"
+            class="xlsx-import__input"
+            aria-label="Seleccionar archivo Excel de reservas del día"
+            (change)="onXlsxSeleccionado($event)"
+          />
+          <button
+            class="btn btn--secondary btn--md"
+            type="button"
+            (click)="xlsxInput.click()"
+          >
+            <span class="btn__icon" aria-hidden="true">
+              <svg class="svg svg--sm" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none">
+                <rect x="4" y="2" width="12" height="16" stroke="currentColor" stroke-width="1.5"/>
+                <polyline points="7,9 10,6 13,9" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="square" stroke-linejoin="miter"/>
+                <line x1="10" y1="6" x2="10" y2="14" stroke="currentColor" stroke-width="1.5" stroke-linecap="square"/>
+              </svg>
+            </span>
+            Seleccionar archivo .xlsx
+          </button>
+
+          @if (xlsxArchivo()) {
+            <span class="xlsx-import__filename">{{ xlsxArchivo()!.name }}</span>
+          }
+        </div>
+
+        <!-- Botón procesar -->
+        @if (xlsxArchivo()) {
+          <div class="xlsx-import__acciones">
+            <button
+              class="btn btn--primary btn--md"
+              type="button"
+              [disabled]="xlsxEnCurso()"
+              [attr.aria-busy]="xlsxEnCurso()"
+              (click)="procesarXlsx()"
+            >
+              @if (xlsxEnCurso()) {
+                Procesando…
+              } @else {
+                Procesar XLSX
+              }
+            </button>
+          </div>
+        }
+
+        <!-- Advertencias del XLSX -->
+        @if (xlsxAdvertencias().length > 0) {
+          <ul class="notif-checkin__advertencias" role="note" aria-label="Advertencias del archivo">
+            @for (w of xlsxAdvertencias(); track w) {
+              <li>{{ w }}</li>
+            }
+          </ul>
+        }
+
+        <!-- Tabla de check-ins del XLSX -->
+        @if (xlsxCheckins().length > 0) {
+          <table class="tabla-checkins" aria-label="Check-ins del XLSX">
+            <thead class="tabla-checkins__head">
+              <tr>
+                <th scope="col">Huésped</th>
+                <th scope="col">Apartamento</th>
+                <th scope="col">Email</th>
+                <th scope="col">Teléfono</th>
+                <th scope="col">Checkout</th>
+              </tr>
+            </thead>
+            <tbody class="tabla-checkins__body">
+              @for (r of xlsxCheckins(); track r.nombre) {
+                <tr>
+                  <td>{{ r.nombre }}</td>
+                  <td>{{ r.apartamento ?? '—' }}</td>
+                  <td>{{ r.email ?? '—' }}</td>
+                  <td>{{ r.telefono ?? '—' }}</td>
+                  <td>{{ r.checkout ?? '—' }}</td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        }
+
+      </div>
+    </section>
+
+    <!-- ── Sección 3: Maestro de apartamentos (referencia) ───────────── -->
+    <section class="panel-seccion" aria-labelledby="titulo-maestro">
+      <h2 class="panel-seccion__titulo" id="titulo-maestro">
+        Maestro de apartamentos
+      </h2>
+      <p class="panel-seccion__desc">
+        Propiedades activas registradas en tu cuenta.
+      </p>
+
+      <div class="panel-seccion__body">
+
+        @if (apartamentos().length === 0) {
+          <p class="notif-checkin__aviso" role="note">
+            No hay apartamentos registrados. Añádelos desde el Maestro de apartamentos.
+          </p>
+        } @else {
+          <ul class="notif-checkin__apt-list">
+            @for (apt of apartamentos(); track apt.id) {
+              <li class="notif-checkin__apt-item">
+                <span class="notif-checkin__apt-nombre">{{ apt.nombre }}</span>
+                @if (apt.ciudad) {
+                  <span class="notif-checkin__apt-ciudad">{{ apt.ciudad }}</span>
+                }
+              </li>
+            }
+          </ul>
+        }
+
+      </div>
+    </section>
+
+    <!-- ── Sección 4: Enviar notificación ────────────────────────────── -->
+    <section class="panel-seccion" aria-labelledby="titulo-notificacion">
+      <h2 class="panel-seccion__titulo" id="titulo-notificacion">
+        Enviar notificación
+      </h2>
+      <p class="panel-seccion__desc">
+        Personaliza el mensaje y envíalo por email. Puedes generar una
+        plantilla automática a partir de los check-ins cargados o escribir
+        el tuyo propio.
+      </p>
+
+      <!-- Bloque de aviso si Gmail no está configurado -->
+      @if (!gmailConfigurado()) {
+        <div class="notif-checkin__gmail-aviso" role="alert">
+          <p>
+            <strong>Gmail SMTP no configurado.</strong>
+            Para habilitar el envío de emails, añade
+            <code>GMAIL_USER</code> y <code>GMAIL_APP_PASSWORD</code>
+            en las variables de entorno del servidor.
+          </p>
+        </div>
+      }
+
+      <div class="panel-seccion__body notif-form">
+
+        <!-- Botón generar plantilla -->
+        <div class="notif-form__plantilla-accion">
+          <button
+            class="btn btn--secondary btn--md"
+            type="button"
+            [disabled]="!hayCheckins()"
+            (click)="generarPlantilla()"
+          >
+            <span class="btn__icon" aria-hidden="true">
+              <svg class="svg svg--sm" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none">
+                <rect x="3" y="3" width="14" height="14" stroke="currentColor" stroke-width="1.5"/>
+                <line x1="6" y1="7" x2="14" y2="7" stroke="currentColor" stroke-width="1.5" stroke-linecap="square"/>
+                <line x1="6" y1="10" x2="14" y2="10" stroke="currentColor" stroke-width="1.5" stroke-linecap="square"/>
+                <line x1="6" y1="13" x2="11" y2="13" stroke="currentColor" stroke-width="1.5" stroke-linecap="square"/>
+              </svg>
+            </span>
+            Generar plantilla
+          </button>
+          @if (!hayCheckins()) {
+            <span class="notif-form__hint">
+              Carga check-ins desde el PMS o XLSX para generar la plantilla.
+            </span>
+          }
+        </div>
+
+        <!-- Destinatario -->
+        <div class="form-group">
+          <label class="form-label" for="notif-destinatario">
+            Enviar a
+          </label>
+          <input
+            id="notif-destinatario"
+            type="email"
+            class="form-input"
+            placeholder="correo@ejemplo.com"
+            [disabled]="!gmailConfigurado()"
+            [(ngModel)]="destinatario"
+            name="destinatario"
+          />
+        </div>
+
+        <!-- Asunto -->
+        <div class="form-group">
+          <label class="form-label" for="notif-asunto">
+            Asunto
+          </label>
+          <input
+            id="notif-asunto"
+            type="text"
+            class="form-input"
+            [disabled]="!gmailConfigurado()"
+            [(ngModel)]="asunto"
+            name="asunto"
+          />
+        </div>
+
+        <!-- Mensaje (editable) -->
+        <div class="form-group">
+          <label class="form-label" for="notif-mensaje">
+            Mensaje
+          </label>
+          <textarea
+            id="notif-mensaje"
+            class="form-textarea notif-form__textarea"
+            rows="12"
+            placeholder="Escribe o genera el mensaje de notificación aquí…"
+            [disabled]="!gmailConfigurado()"
+            [(ngModel)]="mensaje"
+            name="mensaje"
+          ></textarea>
+        </div>
+
+        <!-- Acciones envío -->
+        <div class="form-actions">
+          <button
+            class="btn btn--primary btn--md"
+            type="button"
+            [disabled]="!gmailConfigurado() || enviando() || !destinatario.trim() || !mensaje.trim()"
+            [attr.aria-busy]="enviando()"
+            (click)="enviarNotificacion()"
+          >
+            @if (enviando()) {
+              Enviando…
+            } @else {
+              Enviar notificación
+            }
+          </button>
+        </div>
+
+        <!-- Feedback de envío -->
+        @if (estadoEnvio() === 'ok') {
+          <p class="notif-form__feedback notif-form__feedback--ok" role="status" aria-live="polite">
+            Email enviado correctamente.
+          </p>
+        }
+        @if (estadoEnvio() === 'error') {
+          <p class="notif-form__feedback notif-form__feedback--error" role="alert" aria-live="assertive">
+            {{ errorEnvio() }}
+          </p>
+        }
+
+      </div>
+    </section>
+
+  }
+
+</div>

--- a/frontend/src/app/pages/notificaciones-checkin-tardio/notificaciones-checkin-tardio.scss
+++ b/frontend/src/app/pages/notificaciones-checkin-tardio/notificaciones-checkin-tardio.scss
@@ -1,0 +1,3 @@
+// Estilos del componente notificaciones-checkin-tardio.
+// Siguiendo la convencion del proyecto: los estilos globales van en
+// src/styles/components/ (ITCSS). Este archivo queda vacio por diseno.

--- a/frontend/src/app/pages/notificaciones-checkin-tardio/notificaciones-checkin-tardio.ts
+++ b/frontend/src/app/pages/notificaciones-checkin-tardio/notificaciones-checkin-tardio.ts
@@ -1,0 +1,228 @@
+import { Component, computed, inject, OnInit, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { HttpClient } from '@angular/common/http';
+
+interface CheckinHoy {
+  nombre: string;
+  apartamento: string | null;
+  email: string | null;
+  telefono: string | null;
+  checkin: string | null;
+  checkout: string | null;
+}
+
+interface ApartamentoRef {
+  id: string;
+  nombre: string;
+  ciudad: string | null;
+}
+
+interface StatusResponse {
+  ok: boolean;
+  gmail_configurado: boolean;
+  pms_configurado: boolean;
+  pms_error: string | null;
+  apartamentos: ApartamentoRef[];
+  reservas_pms: CheckinHoy[];
+}
+
+@Component({
+  selector: 'app-notificaciones-checkin-tardio',
+  templateUrl: './notificaciones-checkin-tardio.html',
+  styleUrl: './notificaciones-checkin-tardio.scss',
+  standalone: true,
+  imports: [FormsModule],
+})
+export class NotificacionesCheckinTardioPageComponent implements OnInit {
+
+  private readonly http = inject(HttpClient);
+
+  // ── Estado general ────────────────────────────────────────────────────
+  readonly cargando = signal(true);
+  readonly gmailConfigurado = signal(false);
+  readonly pmsConfigurado = signal(false);
+  readonly pmsError = signal<string | null>(null);
+
+  // ── Datos del día ─────────────────────────────────────────────────────
+  readonly apartamentos = signal<ApartamentoRef[]>([]);
+  readonly reservasPms = signal<CheckinHoy[]>([]);
+
+  // ── XLSX ──────────────────────────────────────────────────────────────
+  readonly xlsxArchivo = signal<File | null>(null);
+  readonly xlsxEnCurso = signal(false);
+  readonly xlsxCheckins = signal<CheckinHoy[]>([]);
+  readonly xlsxAdvertencias = signal<string[]>([]);
+
+  // ── Todos los check-ins disponibles (PMS + XLSX, deduplicados por nombre) ──
+  readonly todosCheckins = computed<CheckinHoy[]>(() => {
+    const pms = this.reservasPms();
+    const xlsx = this.xlsxCheckins();
+    const nombresEnPms = new Set(pms.map(r => r.nombre));
+    const soloXlsx = xlsx.filter(r => !nombresEnPms.has(r.nombre));
+    return [...pms, ...soloXlsx];
+  });
+
+  readonly hayCheckins = computed(() => this.todosCheckins().length > 0);
+
+  // ── Notificación ──────────────────────────────────────────────────────
+  destinatario = '';
+  asunto = 'Recordatorio de check-in';
+  mensaje = '';
+
+  readonly enviando = signal(false);
+  readonly estadoEnvio = signal<'idle' | 'ok' | 'error'>('idle');
+  readonly errorEnvio = signal<string | null>(null);
+
+  // ── Ciclo de vida ─────────────────────────────────────────────────────
+
+  ngOnInit(): void {
+    this.cargarStatus();
+  }
+
+  // ── Carga de estado ───────────────────────────────────────────────────
+
+  private cargarStatus(): void {
+    this.cargando.set(true);
+    this.http.get<StatusResponse>(
+      '/api/notificaciones/checkin-tardio/status'
+    ).subscribe({
+      next: res => {
+        this.gmailConfigurado.set(res.gmail_configurado);
+        this.pmsConfigurado.set(res.pms_configurado);
+        this.pmsError.set(res.pms_error ?? null);
+        this.apartamentos.set(res.apartamentos);
+        this.reservasPms.set(res.reservas_pms);
+        this.cargando.set(false);
+
+        // Pre-generar plantilla si hay datos
+        if (res.reservas_pms.length > 0) {
+          this.mensaje = this._buildPlantilla(res.reservas_pms);
+        }
+      },
+      error: err => {
+        console.error('[notificaciones-checkin-tardio] Error al cargar estado:', err);
+        this.cargando.set(false);
+      },
+    });
+  }
+
+  // ── XLSX ──────────────────────────────────────────────────────────────
+
+  onXlsxSeleccionado(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0] ?? null;
+    this.xlsxArchivo.set(file);
+    this.xlsxCheckins.set([]);
+    this.xlsxAdvertencias.set([]);
+    input.value = '';
+  }
+
+  procesarXlsx(): void {
+    const archivo = this.xlsxArchivo();
+    if (!archivo || this.xlsxEnCurso()) return;
+
+    this.xlsxEnCurso.set(true);
+    const form = new FormData();
+    form.append('file', archivo);
+
+    this.http.post<{ ok: boolean; checkins: CheckinHoy[]; warnings?: string[] }>(
+      '/api/notificaciones/checkin-tardio/xlsx',
+      form,
+    ).subscribe({
+      next: res => {
+        this.xlsxEnCurso.set(false);
+        this.xlsxCheckins.set(res.checkins);
+        this.xlsxAdvertencias.set(res.warnings ?? []);
+        // Regenerar plantilla con todos los datos disponibles
+        const todos = this.todosCheckins();
+        if (todos.length > 0) {
+          this.mensaje = this._buildPlantilla(todos);
+        }
+      },
+      error: err => {
+        this.xlsxEnCurso.set(false);
+        console.error('[notificaciones-checkin-tardio] Error al procesar XLSX:', err);
+      },
+    });
+  }
+
+  // ── Plantilla de mensaje ──────────────────────────────────────────────
+
+  generarPlantilla(): void {
+    const checkins = this.todosCheckins();
+    this.mensaje = this._buildPlantilla(checkins);
+  }
+
+  private _buildPlantilla(checkins: CheckinHoy[]): string {
+    if (checkins.length === 0) return '';
+
+    const hoy = new Date().toLocaleDateString('es-ES', {
+      weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+    });
+
+    if (checkins.length === 1) {
+      const c = checkins[0];
+      const apt = c.apartamento ? ` en ${c.apartamento}` : '';
+      return (
+        `Estimado/a ${c.nombre},\n\n` +
+        `Le recordamos que su check-in${apt} está programado para hoy, ${hoy}.\n\n` +
+        `Si prevé llegar más tarde de lo habitual, le agradecemos que nos lo comunique lo antes posible para poder gestionar correctamente el acceso.\n\n` +
+        `Quedo a su disposición para cualquier consulta.\n\n` +
+        `Saludos cordiales.`
+      );
+    }
+
+    const lista = checkins
+      .map(c => {
+        const apt = c.apartamento ? ` — ${c.apartamento}` : '';
+        const hora = c.checkin ? ` (check-in: ${c.checkin})` : '';
+        return `• ${c.nombre}${apt}${hora}`;
+      })
+      .join('\n');
+
+    return (
+      `Recordatorio de check-ins para hoy, ${hoy}:\n\n` +
+      `${lista}\n\n` +
+      `Si alguno de los huéspedes prevé llegar más tarde de lo habitual, ` +
+      `le agradecemos que nos lo comunique lo antes posible.\n\n` +
+      `Saludos cordiales.`
+    );
+  }
+
+  // ── Envío de notificación ─────────────────────────────────────────────
+
+  enviarNotificacion(): void {
+    if (this.enviando() || !this.gmailConfigurado()) return;
+    if (!this.destinatario.trim() || !this.mensaje.trim()) return;
+
+    this.enviando.set(true);
+    this.estadoEnvio.set('idle');
+    this.errorEnvio.set(null);
+
+    this.http.post<{ ok: boolean; errors?: string[] }>(
+      '/api/notificaciones/checkin-tardio/enviar',
+      {
+        destinatario: this.destinatario.trim(),
+        asunto: this.asunto.trim() || 'Recordatorio de check-in',
+        mensaje: this.mensaje.trim(),
+      },
+    ).subscribe({
+      next: res => {
+        this.enviando.set(false);
+        if (res.ok) {
+          this.estadoEnvio.set('ok');
+        } else {
+          this.estadoEnvio.set('error');
+          this.errorEnvio.set(res.errors?.[0] ?? 'Error desconocido.');
+        }
+      },
+      error: err => {
+        this.enviando.set(false);
+        this.estadoEnvio.set('error');
+        this.errorEnvio.set(
+          err?.error?.errors?.[0] ?? 'No se pudo conectar con el servidor.'
+        );
+      },
+    });
+  }
+}

--- a/frontend/src/app/pages/notificaciones-checkin-tardio/notificaciones-checkin-tardio.ts
+++ b/frontend/src/app/pages/notificaciones-checkin-tardio/notificaciones-checkin-tardio.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject, OnInit, signal } from '@angular/core';
+import { Component, computed, inject, OnDestroy, OnInit, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpClient } from '@angular/common/http';
 
@@ -26,6 +26,8 @@ interface StatusResponse {
   reservas_pms: CheckinHoy[];
 }
 
+type EstadoEnvio = 'idle' | 'ok' | 'error';
+
 @Component({
   selector: 'app-notificaciones-checkin-tardio',
   templateUrl: './notificaciones-checkin-tardio.html',
@@ -33,7 +35,7 @@ interface StatusResponse {
   standalone: true,
   imports: [FormsModule],
 })
-export class NotificacionesCheckinTardioPageComponent implements OnInit {
+export class NotificacionesCheckinTardioPageComponent implements OnInit, OnDestroy {
 
   private readonly http = inject(HttpClient);
 
@@ -70,14 +72,19 @@ export class NotificacionesCheckinTardioPageComponent implements OnInit {
   mensaje = '';
 
   readonly enviando = signal(false);
-  readonly estadoEnvio = signal<'idle' | 'ok' | 'error'>('idle');
+  readonly estadoEnvio = signal<EstadoEnvio>('idle');
   readonly errorEnvio = signal<string | null>(null);
   readonly copiadoOk = signal(false);
+  private _copiadoTimer: ReturnType<typeof setTimeout> | null = null;
 
   // ── Ciclo de vida ─────────────────────────────────────────────────────
 
   ngOnInit(): void {
     this.cargarStatus();
+  }
+
+  ngOnDestroy(): void {
+    if (this._copiadoTimer) clearTimeout(this._copiadoTimer);
   }
 
   // ── Carga de estado ───────────────────────────────────────────────────
@@ -195,8 +202,9 @@ export class NotificacionesCheckinTardioPageComponent implements OnInit {
   copiarMensaje(): void {
     if (!this.mensaje) return;
     navigator.clipboard.writeText(this.mensaje).then(() => {
+      if (this._copiadoTimer) clearTimeout(this._copiadoTimer);
       this.copiadoOk.set(true);
-      setTimeout(() => this.copiadoOk.set(false), 2000);
+      this._copiadoTimer = setTimeout(() => this.copiadoOk.set(false), 2000);
     });
   }
 
@@ -214,7 +222,7 @@ export class NotificacionesCheckinTardioPageComponent implements OnInit {
       '/api/notificaciones/checkin-tardio/enviar',
       {
         destinatario: this.destinatario.trim(),
-        asunto: this.asunto.trim() || 'Recordatorio de check-in',
+        asunto: this.asunto.trim(),
         mensaje: this.mensaje.trim(),
       },
     ).subscribe({

--- a/frontend/src/app/pages/notificaciones-checkin-tardio/notificaciones-checkin-tardio.ts
+++ b/frontend/src/app/pages/notificaciones-checkin-tardio/notificaciones-checkin-tardio.ts
@@ -72,6 +72,7 @@ export class NotificacionesCheckinTardioPageComponent implements OnInit {
   readonly enviando = signal(false);
   readonly estadoEnvio = signal<'idle' | 'ok' | 'error'>('idle');
   readonly errorEnvio = signal<string | null>(null);
+  readonly copiadoOk = signal(false);
 
   // ── Ciclo de vida ─────────────────────────────────────────────────────
 
@@ -187,6 +188,16 @@ export class NotificacionesCheckinTardioPageComponent implements OnInit {
       `le agradecemos que nos lo comunique lo antes posible.\n\n` +
       `Saludos cordiales.`
     );
+  }
+
+  // ── Copiar mensaje ────────────────────────────────────────────────────────
+
+  copiarMensaje(): void {
+    if (!this.mensaje) return;
+    navigator.clipboard.writeText(this.mensaje).then(() => {
+      this.copiadoOk.set(true);
+      setTimeout(() => this.copiadoOk.set(false), 2000);
+    });
   }
 
   // ── Envío de notificación ─────────────────────────────────────────────

--- a/frontend/src/styles/components/_index.scss
+++ b/frontend/src/styles/components/_index.scss
@@ -18,3 +18,4 @@
 @import 'tabla-crud';
 @import 'maestro-apartamentos';
 @import 'sincronizador-contactos';
+@import 'notificaciones-checkin-tardio';

--- a/frontend/src/styles/components/_notificaciones-checkin-tardio.scss
+++ b/frontend/src/styles/components/_notificaciones-checkin-tardio.scss
@@ -1,0 +1,178 @@
+// =============================================================================
+// COMPONENT: notificaciones-checkin-tardio
+// Herramienta de notificaciones para check-in tardíos.
+// Estilos wireframe (escala de grises, blocky) — ITCSS capa Components.
+// =============================================================================
+
+// ── Contenedor raíz ──────────────────────────────────────────────────────
+
+.notif-checkin {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.notif-checkin__cargando {
+  color: var(--color-text-muted, #888);
+  font-size: var(--fs-body);
+}
+
+// ── Avisos genéricos ──────────────────────────────────────────────────────
+
+.notif-checkin__aviso {
+  font-size: var(--fs-body);
+  color: var(--color-text-muted, #666);
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--color-border, #ccc);
+  background-color: var(--color-surface-alt, #f5f5f5);
+
+  &--error {
+    border-color: var(--color-error, #c00);
+    color: var(--color-error, #c00);
+    background-color: #fff0f0;
+  }
+}
+
+// ── Lista de apartamentos de referencia ──────────────────────────────────
+
+.notif-checkin__apt-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.notif-checkin__apt-item {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--color-border, #ccc);
+  background-color: var(--color-surface-alt, #f5f5f5);
+}
+
+.notif-checkin__apt-nombre {
+  font-size: var(--fs-body);
+  font-weight: 600;
+}
+
+.notif-checkin__apt-ciudad {
+  font-size: var(--fs-caption);
+  color: var(--color-text-muted, #666);
+}
+
+// ── Tabla de check-ins ────────────────────────────────────────────────────
+
+.tabla-checkins {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--fs-body);
+}
+
+.tabla-checkins__head {
+  th {
+    text-align: left;
+    padding: 0.5rem 0.75rem;
+    border-bottom: 2px solid var(--color-border, #ccc);
+    font-weight: 600;
+    white-space: nowrap;
+    background-color: var(--color-surface-alt, #f5f5f5);
+  }
+}
+
+.tabla-checkins__body {
+  tr {
+    border-bottom: 1px solid var(--color-border, #ccc);
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
+  td {
+    padding: 0.5rem 0.75rem;
+    vertical-align: top;
+  }
+}
+
+// ── Advertencias del XLSX ─────────────────────────────────────────────────
+
+.notif-checkin__advertencias {
+  list-style: none;
+  margin: 0.5rem 0 0;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--color-border, #ccc);
+  background-color: var(--color-surface-alt, #f5f5f5);
+  font-size: var(--fs-caption);
+  color: var(--color-text-muted, #666);
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+// ── Aviso Gmail no configurado ────────────────────────────────────────────
+
+.notif-checkin__gmail-aviso {
+  margin-bottom: 1rem;
+  padding: 0.75rem 1rem;
+  border: 2px solid var(--color-border, #ccc);
+  background-color: var(--color-surface-alt, #f5f5f5);
+  font-size: var(--fs-body);
+
+  p {
+    margin: 0;
+  }
+
+  code {
+    font-family: monospace;
+    background-color: #e8e8e8;
+    padding: 0.1em 0.3em;
+  }
+}
+
+// ── Formulario de notificación ────────────────────────────────────────────
+
+.notif-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.notif-form__plantilla-accion {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.notif-form__hint {
+  font-size: var(--fs-caption);
+  color: var(--color-text-muted, #888);
+}
+
+.notif-form__textarea {
+  min-height: 14rem;
+  resize: vertical;
+}
+
+// ── Feedback de envío ─────────────────────────────────────────────────────
+
+.notif-form__feedback {
+  font-size: var(--fs-body);
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--color-border, #ccc);
+
+  &--ok {
+    border-color: var(--color-success, #2a7a2a);
+    color: var(--color-success, #2a7a2a);
+    background-color: #f0fff0;
+  }
+
+  &--error {
+    border-color: var(--color-error, #c00);
+    color: var(--color-error, #c00);
+    background-color: #fff0f0;
+  }
+}

--- a/frontend/src/styles/components/_notificaciones-checkin-tardio.scss
+++ b/frontend/src/styles/components/_notificaciones-checkin-tardio.scss
@@ -1,35 +1,68 @@
 // =============================================================================
-// COMPONENT: notificaciones-checkin-tardio
-// Herramienta de notificaciones para check-in tardíos.
-// Estilos wireframe (escala de grises, blocky) — ITCSS capa Components.
+// COMPONENTS: NOTIFICACIONES CHECK-IN TARDÍOS (página)
+//
+// Organismos propios:
+//   .notif-checkin          — wrapper principal de página
+//   .tabla-checkins         — tabla ligera de check-ins (sin toolbar ni selección)
+//   .notif-form             — formulario de envío de notificación
+//
+// Nota: .panel-seccion, .xlsx-import, .form-actions, .form-group, .form-label,
+//       .form-input, .form-textarea, .form-editor están definidos en sus
+//       archivos ITCSS correspondientes. No se redefinen aquí.
 // =============================================================================
 
-// ── Contenedor raíz ──────────────────────────────────────────────────────
+// ── Wrapper de página ─────────────────────────────────────────────────────
 
 .notif-checkin {
+  padding-inline: $space-6;
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: $space-8;
 }
+
+// ── Estado de carga ───────────────────────────────────────────────────────
 
 .notif-checkin__cargando {
-  color: var(--color-text-muted, #888);
-  font-size: var(--fs-body);
+  @include text-body-md;
+  color: $color-text-secondary;
 }
 
-// ── Avisos genéricos ──────────────────────────────────────────────────────
+// ── Aviso genérico (nota informativa / error) ─────────────────────────────
 
 .notif-checkin__aviso {
-  font-size: var(--fs-body);
-  color: var(--color-text-muted, #666);
-  padding: 0.75rem 1rem;
-  border: 1px solid var(--color-border, #ccc);
-  background-color: var(--color-surface-alt, #f5f5f5);
+  @include text-body-sm;
+  color: $color-text-secondary;
+  padding: $space-3 $space-4;
+  border: $border-width $border-style $color-border;
+  background-color: $color-surface-alt;
 
   &--error {
-    border-color: var(--color-error, #c00);
-    color: var(--color-error, #c00);
-    background-color: #fff0f0;
+    border-left: 3px solid $color-gray-700;
+    color: $color-gray-700;
+    background-color: $color-surface;
+  }
+}
+
+// ── Aviso Gmail no configurado ────────────────────────────────────────────
+
+.notif-checkin__gmail-aviso {
+  padding: $space-4;
+  border: $border-width $border-style $color-border;
+  border-left: 3px solid $color-gray-700;
+  background-color: $color-surface-alt;
+  margin-bottom: $space-4;
+
+  p {
+    @include text-body-sm;
+    color: $color-text-primary;
+    margin: 0;
+  }
+
+  code {
+    font-family: monospace;
+    @include text-caption-md;
+    background-color: $color-gray-200;
+    padding: 0.1em 0.35em;
   }
 }
 
@@ -41,94 +74,83 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: $space-2;
 }
 
 .notif-checkin__apt-item {
   display: flex;
   align-items: baseline;
-  gap: 0.5rem;
-  padding: 0.5rem 0.75rem;
-  border: 1px solid var(--color-border, #ccc);
-  background-color: var(--color-surface-alt, #f5f5f5);
+  gap: $space-3;
+  padding: $space-2 $space-4;
+  border: $border-width $border-style $color-border;
+  background-color: $color-surface-alt;
 }
 
 .notif-checkin__apt-nombre {
-  font-size: var(--fs-body);
-  font-weight: 600;
+  @include text-body-md;
+  font-weight: $font-weight-label;
+  color: $color-text-primary;
 }
 
 .notif-checkin__apt-ciudad {
-  font-size: var(--fs-caption);
-  color: var(--color-text-muted, #666);
-}
-
-// ── Tabla de check-ins ────────────────────────────────────────────────────
-
-.tabla-checkins {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: var(--fs-body);
-}
-
-.tabla-checkins__head {
-  th {
-    text-align: left;
-    padding: 0.5rem 0.75rem;
-    border-bottom: 2px solid var(--color-border, #ccc);
-    font-weight: 600;
-    white-space: nowrap;
-    background-color: var(--color-surface-alt, #f5f5f5);
-  }
-}
-
-.tabla-checkins__body {
-  tr {
-    border-bottom: 1px solid var(--color-border, #ccc);
-
-    &:last-child {
-      border-bottom: none;
-    }
-  }
-
-  td {
-    padding: 0.5rem 0.75rem;
-    vertical-align: top;
-  }
+  @include text-caption-md;
+  color: $color-text-secondary;
 }
 
 // ── Advertencias del XLSX ─────────────────────────────────────────────────
 
 .notif-checkin__advertencias {
   list-style: none;
-  margin: 0.5rem 0 0;
-  padding: 0.75rem 1rem;
-  border: 1px solid var(--color-border, #ccc);
-  background-color: var(--color-surface-alt, #f5f5f5);
-  font-size: var(--fs-caption);
-  color: var(--color-text-muted, #666);
+  margin: 0;
+  padding: $space-3 $space-4;
+  border: $border-width $border-style $color-border;
+  background-color: $color-surface-alt;
+  @include text-caption-md;
+  color: $color-text-secondary;
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: $space-1;
 }
 
-// ── Aviso Gmail no configurado ────────────────────────────────────────────
+// ── Tabla de check-ins ────────────────────────────────────────────────────
+// Tabla ligera de sólo lectura (no reutiliza .tabla-crud para no arrastrar
+// la lógica de toolbar, selección múltiple y footer).
 
-.notif-checkin__gmail-aviso {
-  margin-bottom: 1rem;
-  padding: 0.75rem 1rem;
-  border: 2px solid var(--color-border, #ccc);
-  background-color: var(--color-surface-alt, #f5f5f5);
-  font-size: var(--fs-body);
+.tabla-checkins {
+  width: 100%;
+  border-collapse: collapse;
+  @include text-body-sm;
 
-  p {
-    margin: 0;
+  &__head {
+    th {
+      text-align: left;
+      padding: $space-2 $space-4;
+      @include text-label-sm;
+      color: $color-text-secondary;
+      white-space: nowrap;
+      background-color: $color-surface-alt;
+      border-bottom: $border-width $border-style $color-border;
+    }
   }
 
-  code {
-    font-family: monospace;
-    background-color: #e8e8e8;
-    padding: 0.1em 0.3em;
+  &__body {
+    tr {
+      border-bottom: $border-width $border-style $color-border;
+
+      &:last-child {
+        border-bottom: none;
+      }
+
+      &:hover {
+        background-color: $color-gray-50;
+      }
+    }
+
+    td {
+      padding: $space-2 $space-4;
+      vertical-align: top;
+      color: $color-text-primary;
+    }
   }
 }
 
@@ -137,42 +159,51 @@
 .notif-form {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
-}
+  gap: $space-5;
+  max-width: 48rem;
 
-.notif-form__plantilla-accion {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  flex-wrap: wrap;
-}
+  // Fila "Generar plantilla" + hint
+  &__plantilla-accion {
+    display: flex;
+    align-items: center;
+    gap: $space-4;
+    flex-wrap: wrap;
+  }
 
-.notif-form__hint {
-  font-size: var(--fs-caption);
-  color: var(--color-text-muted, #888);
-}
+  &__hint {
+    @include text-caption-md;
+    color: $color-text-secondary;
+  }
 
-.notif-form__textarea {
-  min-height: 14rem;
-  resize: vertical;
+  // Ajuste del form-editor para el área de mensaje:
+  // sin borde-left en la barra (no hay pestañas a su izquierda).
+  .form-editor__toolbar {
+    border-left: none;
+  }
+
+  // Textarea del mensaje — anula el min-height por defecto del form-textarea
+  // y permite redimensión vertical cómoda.
+  .form-textarea {
+    min-height: 14rem;
+  }
 }
 
 // ── Feedback de envío ─────────────────────────────────────────────────────
 
 .notif-form__feedback {
-  font-size: var(--fs-body);
-  padding: 0.75rem 1rem;
-  border: 1px solid var(--color-border, #ccc);
+  @include text-body-sm;
+  padding: $space-3 $space-4;
+  border: $border-width $border-style $color-border;
 
   &--ok {
-    border-color: var(--color-success, #2a7a2a);
-    color: var(--color-success, #2a7a2a);
-    background-color: #f0fff0;
+    border-left: 3px solid $color-gray-500;
+    color: $color-text-primary;
+    background-color: $color-surface-alt;
   }
 
   &--error {
-    border-color: var(--color-error, #c00);
-    color: var(--color-error, #c00);
-    background-color: #fff0f0;
+    border-left: 3px solid $color-gray-700;
+    color: $color-gray-700;
+    background-color: $color-surface;
   }
 }


### PR DESCRIPTION
Nueva herramienta en /menu/notificaciones-checkin-tardio para gestionar y enviar notificaciones a huéspedes con check-in tardío.

Obtiene las reservas de hoy desde el PMS configurado (Smoobu / Beds24) y permite importar un XLSX adicional procesado en memoria sin persistencia (RGPD). Genera automáticamente una plantilla de mensaje editable. Si Gmail SMTP está configurado, permite enviar el mensaje a cualquier destinatario; si no, el formulario de envío queda bloqueado. Incluye botón para copiar el mensaje al portapapeles.

Backend: Blueprint notificaciones con tres endpoints JWT-protegidos (status, xlsx, enviar), factory build_pms_client extraída como módulo compartido (pms/factory.py), función send_via_smtp extraída en common/notifications/gmail.py y reutilizada también en google_contacts.py.

Frontend: componente Angular standalone con signals, computed para deduplicar reservas PMS+XLSX, SCSS con variables y mixins del proyecto, entrada en el sidenav.